### PR TITLE
dockerize application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN npm ci --ignore-scripts --omit-dev
 
 USER node
 
-CMD ["node", "dist/index.js", "--host", "0.0.0.0", "--port", "8080", "--transport", "http"]
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
         delay: 5s
     environment:
       - BRAVE_API_KEY
+      - BRAVE_MCP_TRANSPORT=http
+      - BRAVE_MCP_PORT=8080
+      - BRAVE_MCP_HOST=0.0.0.0
     init: true
     ports:
       - 8080:8080

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,9 +19,9 @@ if (!BRAVE_API_KEY) {
 }
 
 const program = new Command()
-  .option("--transport <stdio|http>", "transport type", "http")
-  .option("--port <number>", "desired port for HTTP transport", "3000")
-  .option("--host <string>", "host address to bind to for HTTP transport", "127.0.0.1")
+  .option("--transport <stdio|http>", "transport type", process.env.BRAVE_MCP_TRANSPORT ?? "stdio")
+  .option("--port <number>", "desired port for HTTP transport", process.env.BRAVE_MCP_PORT ?? "3000")
+  .option("--host <string>", "host address to bind to for HTTP transport", process.env.BRAVE_MCP_HOST ?? "0.0.0.0")
   .allowUnknownOption()
   .parse(process.argv);
 


### PR DESCRIPTION
- Fix `Dockerfile`
- Add `--host` parameter
- Add `docker-compose` config file

How to run it:

```
BRAVE_API_KEY="BSAXXXXXXX" docker-compose up --build
```

or 

```
docker-compose build
docker-compose run --rm -ti -e BRAVE_API_KEY="BSAXXXXXXX" mcp-server
```

or

```
docker build -t brave-search-mcp .
docker run --rm -ti -p 8080:8080 --cap-drop all --read-only -e BRAVE_API_KEY="BSAXXXXXXX" brave-search-mcp
```