### PR TITLE
remove duplicate enum in result_filter

### DIFF
--- a/src/tools/web/params.ts
+++ b/src/tools/web/params.ts
@@ -209,7 +209,6 @@ export const params = z.object({
         'summarizer',
         'videos',
         'web',
-        'summarizer',
         'locations',
         'rich',
       ])


### PR DESCRIPTION
When trying to connect the mcp to [Kiro](https://kiro.dev) calling the `brave_web_search`, `brave_local_search` results in a validation error 

Validation failed calling brave_web_search with args {"query":"artificial intelligence latest developments 2024","summary":true,"count":5}: schema is invalid: data/properties/result_filter/items/enum must NOT have duplicate items (items ## 5 and 8 are identical), data/properties/result_filter/items must be array, data/properties/result_filter/items must match a schema in anyOf

This is because `summarizer` is defined as an enum twice