### PR TITLE
quiet dotenv for stdio mode

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import dotenv from 'dotenv';
-dotenv.config();
+dotenv.config({ debug: false, quiet: true });
 
 type Configuration = {
   transport: 'stdio' | 'http';


### PR DESCRIPTION
# Background

This is a proposed fix for #32.  The dotenv library is writing to stdout currently and this is breaking users that are trying to use the server in stdio mode.