### PR TITLE
adds/improves logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The server supports the following environment variables:
 - `BRAVE_MCP_TRANSPORT`: Transport mode ("http" or "stdio", default: "http")
 - `BRAVE_MCP_PORT`: HTTP server port (default: 8080)
 - `BRAVE_MCP_HOST`: HTTP server host (default: "0.0.0.0")
+- `BRAVE_MCP_LOG_LEVEL`: Desired logging level("debug", "info", "notice", "warning", "error", "critical", "alert", or "emergency", default: "info")
 
 ### Command Line Options
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - BRAVE_MCP_TRANSPORT=http
       - BRAVE_MCP_PORT=8080
       - BRAVE_MCP_HOST=0.0.0.0
+      - BRAVE_MCP_LOG_LEVEL=info
     init: true
     ports:
       - 8080:8080

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.17.1",
+        "@modelcontextprotocol/sdk": "1.17.2",
         "commander": "14.0.0",
         "dotenv": "^17.2.1",
         "express": "5.1.0",
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.1.tgz",
-      "integrity": "sha512-CPle1OQehbWqd25La9Ack5B07StKIxh4+Bf19qnpZKJC1oI22Y0czZHbifjw1UoczIfKBwBDAp/dFxvHG13B5A==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.2.tgz",
+      "integrity": "sha512-EFLRNXR/ixpXQWu6/3Cu30ndDFIFNaqUXcTqsGebujeMan9FzhAaFFswLRiFj61rgygDRr8WO1N+UijjgRxX9g==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "inspector": "npx @modelcontextprotocol/inspector"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.17.1",
+    "@modelcontextprotocol/sdk": "1.17.2",
     "commander": "14.0.0",
     "dotenv": "^17.2.1",
     "express": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "watch": "tsc --watch",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
-    "inspector": "npx @modelcontextprotocol/inspector"
+    "inspector": "npx @modelcontextprotocol/inspector",
+    "inspector:stdio": "npx @modelcontextprotocol/inspector --transport stdio"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.17.2",

--- a/src/BraveAPI/index.ts
+++ b/src/BraveAPI/index.ts
@@ -2,7 +2,6 @@ import type { Endpoints } from './types.js';
 import config from '../config.js';
 import { stringify } from '../utils.js';
 import ClientLogger from '../ClientLogger.js';
-import { mcpServer } from '../server.js';
 
 const typeToPathMap: Record<keyof Endpoints, string> = {
   images: '/res/v1/images/search',

--- a/src/ClientLogger.ts
+++ b/src/ClientLogger.ts
@@ -1,0 +1,89 @@
+// ClientLogger.ts
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { LoggingLevel, SetLevelRequest } from '@modelcontextprotocol/sdk/types.js';
+import { LoggingLevelSchema, SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import config from './config.js';
+
+type LoggerFn = (level: LoggingLevel, message: string) => Promise<void>;
+
+let mcpServer: McpServer | undefined;
+
+const setServer = (server: McpServer) => {
+  mcpServer = server;
+};
+
+let customLogger: LoggerFn | undefined;
+let currentLevel: number = LoggingLevelSchema.options.indexOf(config.loggingLevel);
+
+/**
+ * Attempt to register a custom set level request handler.
+ * If the method is already handled by the SDK/Server, we'll ignore the error.
+ * @see https://github.com/modelcontextprotocol/typescript-sdk/issues/871
+ * @param server {Server} The server to register the handler on.
+ */
+export const maybeRegisterCustomSetLevelRequestHandler = (server: McpServer['server']) => {
+  try {
+    server.assertCanSetRequestHandler(SetLevelRequestSchema.shape.method.value);
+    server.setRequestHandler(
+      SetLevelRequestSchema,
+      async (request: SetLevelRequest): Promise<any> => {
+        await log('info', `Setting logging level to ${request.params.level}`);
+        currentLevel = LoggingLevelSchema.options.indexOf(request.params.level);
+        return {};
+      }
+    );
+  } catch (error) {
+    console.error(
+      `Failed to register custom SetLevelRequest handler. The SDK may now provide it's own handler. See https://github.com/modelcontextprotocol/typescript-sdk/issues/871 for more information.`,
+      error
+    );
+  }
+};
+
+const log = async (level: LoggingLevel, message: string) => {
+  // If a custom logger exists, call it, and let it handle it's own log-level filtering
+  if (customLogger) {
+    await customLogger(level, message);
+    return;
+  }
+
+  // If the log-level is less than the current log-level, skip it
+  if (LoggingLevelSchema.options.indexOf(level) < currentLevel) {
+    return;
+  }
+
+  // Fall back to default logger if no custom logger is set
+  const time = new Date().toISOString();
+
+  if (!mcpServer?.isConnected()) {
+    console.error(`${time} [${level}] ${message}`);
+    return;
+  }
+
+  try {
+    await mcpServer?.server.sendLoggingMessage({ level, data: { message, time } });
+  } catch (error) {
+    console.error(`Error sending logging message: ${error}`);
+  }
+};
+
+const setLogger = (logger: LoggerFn): void => {
+  customLogger = logger;
+};
+
+const setLoggingLevel = (desiredLevel: LoggingLevel): void => {
+  const desiredLevelIndex = LoggingLevelSchema.options.indexOf(desiredLevel);
+
+  if (desiredLevelIndex === -1) {
+    console.error(
+      `Invalid logging level: ${desiredLevel}. Must be one of: ${LoggingLevelSchema.options.join(', ')}`
+    );
+    return;
+  }
+
+  currentLevel = desiredLevelIndex;
+};
+
+const getLoggingLevel = (): LoggingLevel => LoggingLevelSchema.options[currentLevel];
+
+export default { log, setServer, setLogger, setLoggingLevel, getLoggingLevel };

--- a/src/ClientLogger.ts
+++ b/src/ClientLogger.ts
@@ -34,7 +34,7 @@ export const maybeRegisterCustomSetLevelRequestHandler = (server: McpServer['ser
     );
   } catch (error) {
     console.error(
-      `Failed to register custom SetLevelRequest handler. The SDK may now provide it's own handler. See https://github.com/modelcontextprotocol/typescript-sdk/issues/871 for more information.`,
+      `Failed to register custom SetLevelRequest handler. The SDK may now provide its own handler. See https://github.com/modelcontextprotocol/typescript-sdk/issues/871 for more information.`,
       error
     );
   }

--- a/src/ClientLogger.ts
+++ b/src/ClientLogger.ts
@@ -61,7 +61,7 @@ const log = async (level: LoggingLevel, message: string) => {
   }
 
   try {
-    await mcpServer?.server.sendLoggingMessage({ level, data: { message, time } });
+    await mcpServer.server.sendLoggingMessage({ level, data: { message, time } });
   } catch (error) {
     console.error(`Error sending logging message: ${error}`);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { LoggingLevel, LoggingLevelSchema } from '@modelcontextprotocol/sdk/types.js';
 import { Command } from 'commander';
 import dotenv from 'dotenv';
 dotenv.config({ debug: false, quiet: true });
@@ -7,6 +8,7 @@ type Configuration = {
   port: number;
   host: string;
   braveApiKey: string;
+  loggingLevel: LoggingLevel;
 };
 
 const state: Configuration & { ready: boolean } = {
@@ -14,12 +16,14 @@ const state: Configuration & { ready: boolean } = {
   port: 8080,
   host: '0.0.0.0',
   braveApiKey: process.env.BRAVE_API_KEY ?? '',
+  loggingLevel: 'info',
   ready: false,
 };
 
 export function getOptions(): Configuration | false {
   const program = new Command()
     .option('--brave-api-key <string>', 'Brave API key', process.env.BRAVE_API_KEY ?? '')
+    .option('--logging-level <string>', 'Logging level', process.env.BRAVE_MCP_LOG_LEVEL ?? 'info')
     .option('--transport <stdio|http>', 'transport type', process.env.BRAVE_MCP_TRANSPORT ?? 'http')
     .option(
       '--port <number>',
@@ -39,6 +43,13 @@ export function getOptions(): Configuration | false {
   if (!['stdio', 'http'].includes(options.transport)) {
     console.error(
       `Invalid --transport value: '${options.transport}'. Must be one of: stdio, http.`
+    );
+    return false;
+  }
+
+  if (!LoggingLevelSchema.options.includes(options.loggingLevel)) {
+    console.error(
+      `Invalid --logging-level value: '${options.loggingLevel}'. Must be one of: ${LoggingLevelSchema.options.join(', ')}`
     );
     return false;
   }
@@ -69,6 +80,7 @@ export function getOptions(): Configuration | false {
   state.transport = options.transport;
   state.port = options.port;
   state.host = options.host;
+  state.loggingLevel = options.loggingLevel;
   state.ready = true;
 
   return options as Configuration;

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from 'node:crypto';
 import express, { type Request, type Response } from 'express';
 import config from '../config.js';
-import { server } from '../server.js';
+import { mcpServer } from '../server.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
 const yieldGenericServerError = (res: Response) => {
   res.status(500).json({
@@ -11,26 +13,53 @@ const yieldGenericServerError = (res: Response) => {
   });
 };
 
-export const start = () => {
-  if (!config.ready) {
-    console.error('Invalid configuration');
-    process.exit(1);
+const transports = new Map<string, StreamableHTTPServerTransport>();
+
+export const getTransport = async (request: Request): Promise<StreamableHTTPServerTransport> => {
+  // Check for an existing session
+  const sessionId = request.headers['mcp-session-id'] as string;
+
+  if (sessionId && transports.has(sessionId)) {
+    return transports.get(sessionId)!;
   }
 
+  // Is the client attempting to initialize a new session?
+  if (isInitializeRequest(request.body)) {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sessionId) => {
+        transports.set(sessionId, transport);
+      },
+    });
+
+    await mcpServer.connect(transport);
+    return transport;
+  }
+
+  // We have a special case where we'll permit ListToolsRequest w/o a session ID
+  if (request.body.method === ListToolsRequestSchema.shape.method.value) {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    await mcpServer.connect(transport);
+    return transport;
+  }
+
+  throw new Error('Invalid request');
+};
+
+export const createApp = () => {
   const app = express();
 
   app.use(express.json());
 
   app.all('/mcp', async (req: Request, res: Response) => {
     try {
-      const transport = new StreamableHTTPServerTransport({
-        // Setting to undefined will opt-out of session-id generation
-        sessionIdGenerator: undefined,
-      });
-
-      await server.connect(transport);
+      const transport = await getTransport(req);
       await transport.handleRequest(req, res, req.body);
     } catch (error) {
+      console.error(error);
       if (!res.headersSent) {
         yieldGenericServerError(res);
       }
@@ -41,9 +70,20 @@ export const start = () => {
     res.status(200).json({ message: 'pong' });
   });
 
+  return app;
+};
+
+export const start = () => {
+  if (!config.ready) {
+    console.error('Invalid configuration');
+    process.exit(1);
+  }
+
+  const app = createApp();
+
   app.listen(config.port, config.host, () => {
     console.error(`Server is running on http://${config.host}:${config.port}/mcp`);
   });
 };
 
-export default { start };
+export default { start, createApp };

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -46,7 +46,7 @@ export const getTransport = async (request: Request): Promise<StreamableHTTPServ
     return transport;
   }
 
-  throw new Error('Invalid request');
+  throw new Error('Invalid request: must be an initialization request, include a valid session ID, or be a ListTools method request');
 };
 
 export const createApp = () => {

--- a/src/protocols/stdio.ts
+++ b/src/protocols/stdio.ts
@@ -1,10 +1,14 @@
-import { server } from '../server.js';
+import { mcpServer } from '../server.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
+export const createTransport = (): StdioServerTransport => {
+  return new StdioServerTransport();
+};
+
 export const start = async (): Promise<void> => {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  const transport = createTransport();
+  await mcpServer.connect(transport);
   console.error('Stdio server started');
 };
 
-export default { start };
+export default { start, createTransport };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import tools from './tools/index.js';
+import ClientLogger, { maybeRegisterCustomSetLevelRequestHandler } from './ClientLogger.js';
 
-export const server = new McpServer(
+export const mcpServer = new McpServer(
   {
     version: '0.1.0',
     name: 'brave-search-mcp-server',
@@ -16,6 +17,10 @@ export const server = new McpServer(
   }
 );
 
+ClientLogger.setServer(mcpServer);
+// https://github.com/modelcontextprotocol/typescript-sdk/issues/871
+maybeRegisterCustomSetLevelRequestHandler(mcpServer.server);
+
 for (const tool of Object.values(tools)) {
-  server.tool(tool.name, tool.description, tool.inputSchema, tool.annotations, tool.execute);
+  mcpServer.tool(tool.name, tool.description, tool.inputSchema, tool.annotations, tool.execute);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,8 +12,7 @@ export const server = new McpServer(
       logging: {},
       tools: { listChanged: false },
     },
-    instructions:
-      'Use this server to search the Web for various types of data ' + 'via the Brave Search API.',
+    instructions: `Use this server to search the Web for various types of data via the Brave Search API.`,
   }
 );
 

--- a/src/tools/images/index.ts
+++ b/src/tools/images/index.ts
@@ -5,7 +5,8 @@ import type {
 } from '@modelcontextprotocol/sdk/types.js';
 import params, { type QueryParams } from './params.js';
 import API from '../../BraveAPI/index.js';
-import { log, stringify } from '../../utils.js';
+import { stringify } from '../../utils.js';
+import ClientLogger from '../../ClientLogger.js';
 
 export const name = 'brave_image_search';
 
@@ -44,7 +45,7 @@ export const execute = async (params: QueryParams) => {
 };
 
 async function fetchImage(url: string): Promise<{ mimeType: string; data: string } | null> {
-  await log('info', `Fetching image data from ${url}`);
+  await ClientLogger.log('info', `Fetching image data from ${url}`);
   try {
     const response = await fetch(url);
     const buffer = await response.arrayBuffer();
@@ -53,7 +54,7 @@ async function fetchImage(url: string): Promise<{ mimeType: string; data: string
       mimeType: response.headers.get('content-type') ?? 'image/jpeg',
     };
   } catch (error) {
-    await log('error', `Error fetching image data from ${url}: ${error}`);
+    await ClientLogger.log('error', `Error fetching image data from ${url}: ${error}`);
     return null;
   }
 }

--- a/src/tools/local/index.ts
+++ b/src/tools/local/index.ts
@@ -8,7 +8,7 @@ import webParams, { type QueryParams as WebQueryParams } from '../web/params.js'
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import API from '../../BraveAPI/index.js';
 import { formatWebResults } from '../web/index.js';
-import { log, stringify } from '../../utils.js';
+import { stringify } from '../../utils.js';
 import { WebSearchApiResponse } from '../web/types.js';
 
 export const name = 'brave_local_search';

--- a/src/tools/summarizer/index.ts
+++ b/src/tools/summarizer/index.ts
@@ -3,7 +3,7 @@ import { summarizerQueryParams, type SummarizerQueryParams } from './params.js';
 import API from '../../BraveAPI/index.js';
 import { type QueryParams as WebQueryParams } from '../web/params.js';
 import { SummarizerSearchApiResponse } from './types.js';
-import { log } from '../../utils.js';
+import ClientLogger from '../../ClientLogger.js';
 
 export const name = 'brave_summarizer';
 
@@ -82,7 +82,7 @@ const pollForSummary = async (
         result = response;
       }
     } catch (error) {
-      await log('error', `Error polling for summarizer results: ${error}`);
+      await ClientLogger.log('error', `Error polling for summarizer results: ${error}`);
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,17 +1,10 @@
-import type { LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
 import { RATE_LIMIT } from './constants.js';
-import { server } from './server.js';
 
 let requestCount = {
   second: 0,
   month: 0,
   lastReset: Date.now(),
 };
-
-export async function log(level: LoggingLevel, message: string) {
-  const time = new Date().toISOString();
-  await server.server.sendLoggingMessage({ level, data: { message, time } });
-}
 
 export function checkRateLimit() {
   const now = Date.now();


### PR DESCRIPTION
The server previously announced support for logging during the initialization process, but failed to handle _SetLevel_ requests from clients like MCP Inspector. This change introduces handling overall improvements to logging. As a means to this end, support for session IDs were reintroduced, however a session-less request for _ListTools_ is still supported as this was an earlier requirement.

These changes have been tested against both the HTTP and STDIO transports.