### PR TITLE
docs: Add docker.io registry prefix to container image reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Add this to your `claude_desktop_config.json`:
   "mcpServers": {
     "brave-search": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "-e", "BRAVE_API_KEY", "mcp/brave-search"],
+      "args": ["run", "-i", "--rm", "-e", "BRAVE_API_KEY", "docker.io/mcp/brave-search"],
       "env": {
         "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
       }


### PR DESCRIPTION
This prevents the following blocking interaction, e.g. on Fedora Linux:

```
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
? Please select an image:
  ▸ registry.fedoraproject.org/mcp/brave-search:latest
    registry.access.redhat.com/mcp/brave-search:latest
    docker.io/mcp/brave-search:latest
```