### PR TITLE
Update Dockerfile to use openssl-3.5.4-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine@sha256:77f3c4d1f33c17dfa4af4b0add57d86957187873e313c2c37f52831d117645c8 AS builder
 
-RUN apk add --no-cache openssl=3.5.3-r1
+RUN apk add --no-cache openssl=openssl-3.5.4-r0
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN npm run build
 
 FROM node:alpine@sha256:77f3c4d1f33c17dfa4af4b0add57d86957187873e313c2c37f52831d117645c8 AS release
 
-RUN apk add --no-cache openssl=3.5.3-r1
+RUN apk add --no-cache openssl=openssl-3.5.4-r0
 
 WORKDIR /app
 


### PR DESCRIPTION
- **Updated build release to use only one docker build and added build configuration check**
- **Update Dockerfile to use openssl-3.5.4-r0**
