### PR TITLE
Remove EntityTags from StartChangeSet yaml template

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -141,7 +141,6 @@ jobs:
         env:
           IMAGE_RELEASE_TAG: ${{ steps.bump-version.outputs.tag }}
         run: |
-          yq -i '(.ChangeSet[].EntityTags | ( .[] | select(.Key == "Release") ) | .Value) = "$IMAGE_RELEASE_TAG"' marketplace-revision-release.yaml
           yq -i '.ChangeSet[].DetailsDocument.Version.VersionTitle = "Release $IMAGE_RELEASE_TAG"' marketplace-revision-release.yaml
           yq -i '(.ChangeSetTags[] | ( .[] | select(.Key == "Release") ) | .Value) = $IMAGE_RELEASE_TAG' marketplace-revision-release.yaml
           yq -i '.ChangeSetName = "Add New Release $IMAGE_RELEASE_TAG"' marketplace-revision-release.yaml

--- a/marketplace-revision-release.yaml
+++ b/marketplace-revision-release.yaml
@@ -5,13 +5,6 @@ ChangeSet:
     Entity:
       Type: 'ContainerProduct@1.0'
       Identifier: 'prod-ixigokshzjrpw@41'
-    EntityTags:
-      - Key: 'Release'
-        Value: ''
-      - Key: 'CostEntity'
-        Value: 'SEZC'
-      - Key: 'IPGroup'
-        Value: 'KY BAT Ledger Service'
     DetailsDocument: {
       "Version": {
         "ReleaseNotes": "",


### PR DESCRIPTION
Fix to address:

```
   An error occurred (ValidationException) when calling the StartChangeSet operation: [Requested change set name 'Add New Release $IMAGE_RELEASE_TAG' is invalid. It should match with ^[\w\s+=.:@-]{1,100}$., Tags not supported for change type 'AddDeliveryOptions'. Entity tagging through StartChangeSet is supported only for Create change types.]
```
