### PR TITLE
Update Docker Image Build to not include SBOM and Provenance

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -129,7 +129,8 @@ jobs:
         with:
           platforms: linux/amd64,linux/aarch64
           push: true
-          sbom: true
+          sbom: false
+          provenance: false
           tags: |
             ${{ env.DOCKER_REGISTRY }}:${{ env.IMAGE_RELEASE_TAG }}
             ${{ env.DOCKER_REGISTRY }}:${{ github.sha }}


### PR DESCRIPTION
Docker builds can have the option of enabling [build attestations](https://docs.docker.com/build/metadata/attestations/).  Container-based product requirements for AWS marketplace require the image must not include layers with unsupported architectures (reference: https://docs.aws.amazon.com/marketplace/latest/userguide/container-product-policies.html#container-security-requirements).
