### PR TITLE
Add Authorization header support for API keys in HTTP transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN npm ci --ignore-scripts --omit-dev
 
 USER node
 
-CMD ["node", "dist/index.js"]
+ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -110,13 +110,32 @@ Generates AI-powered summaries from web search results using Brave's summarizati
 
 The server supports the following environment variables:
 
-- `BRAVE_API_KEY`: Your Brave Search API key (required)
+- `BRAVE_API_KEY`: Your Brave Search API key (required for STDIO transport, optional for HTTP transport if using Authorization header)
 - `BRAVE_MCP_TRANSPORT`: Transport mode ("http" or "stdio", default: "stdio")
 - `BRAVE_MCP_PORT`: HTTP server port (default: 8080)
 - `BRAVE_MCP_HOST`: HTTP server host (default: "0.0.0.0")
 - `BRAVE_MCP_LOG_LEVEL`: Desired logging level("debug", "info", "notice", "warning", "error", "critical", "alert", or "emergency", default: "info")
 - `BRAVE_MCP_ENABLED_TOOLS`: When used, specifies a whitelist for supported tools
 - `BRAVE_MCP_DISABLED_TOOLS`: When used, specifies a blacklist for supported tools
+
+### HTTP Transport Mode
+
+When using HTTP transport, you have two options for providing the API key:
+
+1. **Environment Variable** (traditional): Set `BRAVE_API_KEY` when starting the server
+2. **Authorization Header** (recommended): Send the API key with each request using the `Authorization` header
+
+**Authorization Header Format:**
+```
+Authorization: Bearer YOUR_API_KEY_HERE
+```
+
+Or simply:
+```
+Authorization: YOUR_API_KEY_HERE
+```
+
+If both the environment variable and Authorization header are provided, the Authorization header takes precedence for that request.
 
 ### Command Line Options
 

--- a/src/BraveAPI/index.ts
+++ b/src/BraveAPI/index.ts
@@ -1,6 +1,20 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Endpoints } from './types.js';
 import config from '../config.js';
 import { stringify } from '../utils.js';
+
+// AsyncLocalStorage for request-scoped API key (used in HTTP transport mode)
+const apiKeyStorage = new AsyncLocalStorage<string>();
+
+// Set API key for current async context (HTTP requests)
+export function setRequestApiKey(apiKey: string): void {
+  apiKeyStorage.enterWith(apiKey);
+}
+
+// Get API key from current context or fallback to config
+function getApiKey(): string {
+  return apiKeyStorage.getStore() ?? config.braveApiKey;
+}
 
 const typeToPathMap: Record<keyof Endpoints, string> = {
   images: '/res/v1/images/search',
@@ -16,7 +30,7 @@ const getDefaultRequestHeaders = (): Record<string, string> => {
   return {
     Accept: 'application/json',
     'Accept-Encoding': 'gzip',
-    'X-Subscription-Token': config.braveApiKey,
+    'X-Subscription-Token': getApiKey(),
   };
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,9 +116,11 @@ export function getOptions(): Configuration | false {
     return false;
   }
 
-  if (!options.braveApiKey) {
+  // For HTTP transport, API key can be provided via Authorization header
+  // For STDIO transport, API key is required at startup
+  if (!options.braveApiKey && options.transport !== 'http') {
     console.error(
-      'Error: --brave-api-key is required. You can get one at https://brave.com/search/api/.'
+      'Error: --brave-api-key is required for STDIO transport. You can get one at https://brave.com/search/api/.'
     );
     return false;
   }

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -4,6 +4,7 @@ import config from '../config.js';
 import createMcpServer from '../server.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ListToolsRequest, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { setRequestApiKey } from '../BraveAPI/index.js';
 
 const yieldGenericServerError = (res: Response) => {
   res.status(500).json({
@@ -57,6 +58,29 @@ const createApp = () => {
 
   app.all('/mcp', async (req: Request, res: Response) => {
     try {
+      const authHeader = req.headers.authorization;
+      let apiKey = config.braveApiKey; // Use default from config if available
+
+      if (authHeader) {
+        // Support both "Bearer <token>" and direct token formats
+        apiKey = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : authHeader;
+      }
+
+      if (!apiKey) {
+        res.status(401).json({
+          id: null,
+          jsonrpc: '2.0',
+          error: {
+            code: -32001,
+            message:
+              'API key required. Provide via Authorization header or BRAVE_API_KEY environment variable.',
+          },
+        });
+        return;
+      }
+
+      setRequestApiKey(apiKey);
+
       const transport = await getTransport(req);
       await transport.handleRequest(req, res, req.body);
     } catch (error) {


### PR DESCRIPTION
- Add support for API key authentication via Authorization header in HTTP transport mode
- Implement request-scoped API key handling using AsyncLocalStorage
- Update README with HTTP transport API key usage instructions and examples
- Replace CMD with ENTRYPOINT in Dockerfile for better container practices

Closes #176