### PR TITLE
Update MCP Protocol schema version to 2025-12-11

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.brave/brave-search-mcp-server",
   "description": "Brave Search MCP Server: web results, images, videos, rich results, AI summaries, and more.",
   "version": "2.0.64",


### PR DESCRIPTION
Update MCP schema version to 2025-12-11
- https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json
- https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md#2025-12-11
