### PR TITLE
fix: remove .trim() call on array types in getOptions()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -115,7 +115,7 @@ export function getOptions(): Configuration | false {
   // Validate tool inclusion configuration
   const { enabledTools, disabledTools } = options;
 
-  if (enabledTools.trim().length > 0 && disabledTools.trim().length > 0) {
+  if (enabledTools.length > 0 && disabledTools.length > 0) {
     console.error('Error: --enabled-tools and --disabled-tools cannot be used together');
     return false;
   }


### PR DESCRIPTION
## Summary

Fixes #225

`enabledTools` and `disabledTools` are arrays (from Commander's `<names...>` syntax), not strings. Calling `.trim()` on them causes:

```
TypeError: enabledTools.trim is not a function
    at getOptions (config.js:73:22)
```

## Changes

- Remove `.trim()` call on line 118 since arrays don't have this method
- The `.length` check is sufficient for arrays

## Testing

- Built locally with `npm run build`
- Tested with goose MCP client - extension loads and searches work correctly

## Root Cause

The regression was introduced when "trims values before checking lengths" was added, but the code path for CLI args (which returns arrays) was not accounted for.