### PR TITLE
feat: add proxy configuration support

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,44 @@
+# feat: add proxy configuration support
+
+This PR adds support for configuring a custom proxy URL for API requests.
+
+## Changes
+
+### New Features
+- Add `BRAVE_PROXY_URL` environment variable support
+- Add `--proxy-url` CLI option for runtime configuration
+- Support HTTP, HTTPS, SOCKS4, and SOCKS5 proxy protocols
+
+### Technical Details
+- Added `proxy-agent` dependency for proxy support
+- Updated configuration schema to include proxy options
+- Modified `BraveAPI/index.ts` to use configured proxy
+
+### Documentation
+- Added proxy configuration section to README
+- Documented all proxy types and usage examples
+
+## Usage
+
+**Environment Variable:**
+```bash
+export BRAVE_PROXY_URL="http://127.0.0.1:7890"
+```
+
+**CLI Option:**
+```bash
+node dist/index.js --brave-api-key YOUR_API_KEY --proxy-url "http://127.0.0.1:7890"
+```
+
+**Docker:**
+```json
+{
+  "mcpServers": {
+    "brave-search": {
+      "env": {
+        "BRAVE_PROXY_URL": "http://127.0.0.1:7890"
+      }
+    }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The server supports the following environment variables:
 - `BRAVE_MCP_ENABLED_TOOLS`: When used, specifies a whitelist for supported tools
 - `BRAVE_MCP_DISABLED_TOOLS`: When used, specifies a blacklist for supported tools
 - `BRAVE_MCP_STATELESS`: HTTP stateless mode (default: "true").  When running on Amazon Bedrock Agentcore, set to "true".
+- `BRAVE_PROXY_URL`: Proxy URL for API requests (e.g., "http://127.0.0.1:7890"). Supports HTTP, HTTPS, SOCKS4, and SOCKS5 proxies.
 
 ### Command Line Options
 
@@ -135,9 +136,47 @@ Options:
   --enabled-tools             Tools whitelist (only the specified tools will be enabled)
   --disabled-tools            Tools blacklist (included tools will be disabled)
   --stateless  <boolean>      HTTP Stateless flag
+  --proxy-url <string>        Proxy URL for API requests (e.g., http://127.0.0.1:7890)
 ```
 
-## Installation
+### Using a Proxy
+
+### Using a Proxy
+
+If you need to route API requests through a proxy (for example, in restricted network environments), you can configure a proxy URL using either an environment variable or a command line option:
+
+**Using Environment Variable:**
+```bash
+export BRAVE_PROXY_URL="http://127.0.0.1:7890"
+node dist/index.js --brave-api-key YOUR_API_KEY
+```
+
+**Using Command Line Option:**
+```bash
+node dist/index.js --brave-api-key YOUR_API_KEY --proxy-url "http://127.0.0.1:7890"
+```
+
+**Supported Proxy Types:**
+- HTTP proxy: `http://host:port`
+- HTTPS proxy: `https://host:port`
+- SOCKS4 proxy: `socks4://host:port`
+- SOCKS5 proxy: `socks5://host:port`
+
+**Example with Docker:**
+```json
+{
+  "mcpServers": {
+    "brave-search": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "BRAVE_API_KEY", "-e", "BRAVE_PROXY_URL", "mcp/brave-search"],
+      "env": {
+        "BRAVE_API_KEY": "YOUR_API_KEY_HERE",
+        "BRAVE_PROXY_URL": "http://127.0.0.1:7890"
+      }
+    }
+  }
+}
+```
 
 ### Installing via Smithery
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "commander": "14.0.2",
     "dotenv": "17.2.3",
     "express": "5.2.1",
+    "proxy-agent": "^6.4.0",
     "zod": "4.3.5"
   },
   "devDependencies": {

--- a/src/BraveAPI/index.ts
+++ b/src/BraveAPI/index.ts
@@ -1,6 +1,7 @@
 import type { Endpoints } from './types.js';
 import config from '../config.js';
 import { stringify } from '../utils.js';
+import { ProxyAgent } from 'proxy-agent';
 
 const typeToPathMap: Record<keyof Endpoints, string> = {
   images: '/res/v1/images/search',
@@ -91,7 +92,17 @@ async function issueRequest<T extends keyof Endpoints>(
   // Issue Request
   const urlWithParams = url.toString() + '?' + queryParams.toString();
   const headers = { ...getDefaultRequestHeaders(), ...requestHeaders } as Headers;
-  const response = await fetch(urlWithParams, { headers });
+
+  // Build fetch options
+  const fetchOptions: RequestInit = { headers };
+
+  // Use custom proxy if configured
+  if (config.proxyUrl) {
+    const agent = new ProxyAgent(config.proxyUrl);
+    fetchOptions.agent = agent as any;
+  }
+
+  const response = await fetch(urlWithParams, fetchOptions);
 
   // Handle Error
   if (!response.ok) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,11 @@ export const configSchema = z.object({
     .default(false)
     .describe('Whether the server should be stateless')
     .optional(),
+  proxyUrl: z
+    .string()
+    .describe('Proxy URL for API requests (e.g., http://127.0.0.1:7890)')
+    .default(process.env.BRAVE_PROXY_URL ?? '')
+    .optional(),
 });
 
 export type SmitheryConfig = z.infer<typeof configSchema>;
@@ -52,6 +57,7 @@ type Configuration = {
   enabledTools: string[];
   disabledTools: string[];
   stateless: boolean;
+  proxyUrl: string;
 };
 
 const state: Configuration & { ready: boolean } = {
@@ -64,6 +70,7 @@ const state: Configuration & { ready: boolean } = {
   enabledTools: [],
   disabledTools: [],
   stateless: false,
+  proxyUrl: process.env.BRAVE_PROXY_URL ?? '',
 };
 
 export function isToolPermittedByUser(toolName: string): boolean {
@@ -105,6 +112,11 @@ export function getOptions(): Configuration | false {
       '--stateless <boolean>',
       'whether the server should be stateless',
       process.env.BRAVE_MCP_STATELESS === 'true' ? true : false
+    )
+    .option(
+      '--proxy-url <string>',
+      'proxy URL for API requests (e.g., http://127.0.0.1:7890)',
+      process.env.BRAVE_PROXY_URL ?? ''
     )
     .allowUnknownOption()
     .parse(process.argv);
@@ -178,6 +190,7 @@ export function getOptions(): Configuration | false {
   state.enabledTools = options.enabledTools;
   state.disabledTools = options.disabledTools;
   state.stateless = options.stateless;
+  state.proxyUrl = options.proxyUrl;
   state.ready = true;
 
   return options as Configuration;


### PR DESCRIPTION
# feat: add proxy configuration support

This PR adds support for configuring a custom proxy URL for API requests.

## Changes

### New Features
- Add `BRAVE_PROXY_URL` environment variable support
- Add `--proxy-url` CLI option for runtime configuration
- Support HTTP, HTTPS, SOCKS4, and SOCKS5 proxy protocols

### Technical Details
- Added `proxy-agent` dependency for proxy support
- Updated configuration schema to include proxy options
- Modified `BraveAPI/index.ts` to use configured proxy

### Documentation
- Added proxy configuration section to README
- Documented all proxy types and usage examples

## Usage

**Environment Variable:**
```bash
export BRAVE_PROXY_URL="http://127.0.0.1:7890"
```

**CLI Option:**
```bash
node dist/index.js --brave-api-key YOUR_API_KEY --proxy-url "http://127.0.0.1:7890"
```

**Docker:**
```json
{
  "mcpServers": {
    "brave-search": {
      "env": {
        "BRAVE_PROXY_URL": "http://127.0.0.1:7890"
      }
    }
  }
}
```
