### PR TITLE
feat: add brave_llm_context tool for LLM Context API

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ Generates AI-powered summaries from web search results using Brave's summarizati
 
 **Usage:** First perform a web search with `summary: true`, then use the returned summary key with this tool.
 
+### LLM Context (`brave_llm_context`)
+Searches the web and returns pre-extracted, LLM-optimized content including markdown text, structured data, code blocks, forum discussions, and YouTube captions. Unlike `brave_web_search` which returns URLs and snippets, this tool returns the actual extracted page content ready for LLM consumption.
+
+**Parameters:**
+- `query` (string, required): Search terms (max 400 chars, 50 words)
+- `country` (string, optional): Country code (default: "US")
+- `search_lang` (string, optional): Search language (default: "en")
+- `count` (number, optional): Results to consider (1-50, default: 20)
+- `maximum_number_of_urls` (number, optional): Max URLs to extract from (1-50, default: 20)
+- `maximum_number_of_tokens` (number, optional): Total token budget (1024-32768, default: 8192)
+- `maximum_number_of_snippets` (number, optional): Max snippets across results (1-100, default: 50)
+- `maximum_number_of_tokens_per_url` (number, optional): Per-URL token limit (512-8192, default: 4096)
+- `maximum_number_of_snippets_per_url` (number, optional): Per-URL snippet limit (1-100, default: 50)
+- `context_threshold_mode` (string, optional): Relevance filtering ("strict", "balanced", "lenient", "disabled", default: "balanced")
+- `enable_local` (boolean, optional): Enable location-aware results (auto-detected if not specified)
+- `goggles` (array, optional): Custom re-ranking definitions
+
+**Note:** Requires a Search plan or higher. See the [LLM Context API documentation](https://api-dashboard.search.brave.com/documentation/services/llm-context) for details.
+
 ## Configuration
 
 ### Getting an API Key

--- a/src/BraveAPI/index.ts
+++ b/src/BraveAPI/index.ts
@@ -10,6 +10,7 @@ const typeToPathMap: Record<keyof Endpoints, string> = {
   videos: '/res/v1/videos/search',
   web: '/res/v1/web/search',
   summarizer: '/res/v1/summarizer/search',
+  llmContext: '/res/v1/llm/context',
 };
 
 const getDefaultRequestHeaders = (): Record<string, string> => {

--- a/src/BraveAPI/types.ts
+++ b/src/BraveAPI/types.ts
@@ -4,8 +4,10 @@ import type { QueryParams as VideoQueryParams } from '../tools/videos/params.js'
 import type { QueryParams as NewsQueryParams } from '../tools/news/params.js';
 import type { LocalPoisParams, LocalDescriptionsParams } from '../tools/local/params.js';
 import type { SummarizerQueryParams } from '../tools/summarizer/params.js';
+import type { QueryParams as LlmContextQueryParams } from '../tools/llm-context/params.js';
 import type { WebSearchApiResponse } from '../tools/web/types.js';
 import type { SummarizerSearchApiResponse } from '../tools/summarizer/types.js';
+import type { LlmContextApiResponse } from '../tools/llm-context/types.js';
 import type { ImageSearchApiResponse } from '../tools/images/types.js';
 import type { VideoSearchApiResponse } from '../tools/videos/types.js';
 import type { NewsSearchApiResponse } from '../tools/news/types.js';
@@ -67,6 +69,11 @@ export type Endpoints = {
   summarizer: {
     params: SummarizerQueryParams;
     response: SummarizerSearchApiResponse;
+    requestHeaders: Headers;
+  };
+  llmContext: {
+    params: LlmContextQueryParams;
+    response: LlmContextApiResponse;
     requestHeaders: Headers;
   };
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import VideoSearchTool from './videos/index.js';
 import ImageSearchTool from './images/index.js';
 import NewsSearchTool from './news/index.js';
 import SummarizerTool from './summarizer/index.js';
+import LlmContextTool from './llm-context/index.js';
 
 export default {
   WebSearchTool,
@@ -12,4 +13,5 @@ export default {
   ImageSearchTool,
   NewsSearchTool,
   SummarizerTool,
+  LlmContextTool,
 };

--- a/src/tools/llm-context/index.ts
+++ b/src/tools/llm-context/index.ts
@@ -1,0 +1,104 @@
+import type { TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import params, { type QueryParams } from './params.js';
+import API from '../../BraveAPI/index.js';
+import type {
+  LlmContextApiResponse,
+  LlmContextGroundingEntry,
+  FormattedLlmContextResults,
+} from './types.js';
+import { stringify } from '../../utils.js';
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export const name = 'brave_llm_context';
+
+export const annotations: ToolAnnotations = {
+  title: 'Brave LLM Context',
+  openWorldHint: true,
+};
+
+export const description = `
+    Searches the web using the Brave LLM Context API and returns pre-extracted, LLM-optimized content including markdown text, structured data, code blocks, forum discussions, and YouTube captions.
+
+    When to use:
+        - When you need the actual page content for grounding LLM responses, not just URLs and snippets
+        - For research requiring extracted text from multiple web pages
+        - When building comprehensive answers that synthesize information from several sources
+        - For fact-checking or verification tasks requiring source content
+        - When you need structured, token-budgeted content from web searches
+
+    When NOT to use (use brave_web_search instead):
+        - When you only need URLs and brief descriptions
+        - For simple navigational queries
+        - When searching for images, videos, or news specifically
+        - When you need location/business details (use brave_local_search)
+
+    Returns a JSON list of grounding results with URL, title, and extracted text snippets from each source, along with source metadata.
+`;
+
+export const execute = async (params: QueryParams) => {
+  const response = { content: [] as TextContent[], isError: false };
+  const data = await API.issueRequest<'llmContext'>('llmContext', params);
+
+  if (
+    !data.grounding ||
+    !Array.isArray(data.grounding.generic) ||
+    data.grounding.generic.length < 1
+  ) {
+    response.isError = true;
+    response.content.push({
+      type: 'text' as const,
+      text: 'No LLM context results found',
+    });
+
+    return response;
+  }
+
+  for (const entry of formatGroundingResults(data.grounding.generic)) {
+    response.content.push({
+      type: 'text' as const,
+      text: stringify(entry),
+    });
+  }
+
+  // Include source metadata if available
+  if (data.sources && Object.keys(data.sources).length > 0) {
+    response.content.push({
+      type: 'text' as const,
+      text: stringify({ sources: data.sources }),
+    });
+  }
+
+  return response;
+};
+
+export const formatGroundingResults = (
+  generic: LlmContextGroundingEntry[]
+): FormattedLlmContextResults => {
+  return (generic || []).map(({ url, title, snippets }) => ({
+    url,
+    title,
+    snippets,
+  }));
+};
+
+export const register = (mcpServer: McpServer) => {
+  mcpServer.registerTool(
+    name,
+    {
+      title: name,
+      description: description,
+      inputSchema: params.shape,
+      annotations: annotations,
+    },
+    execute
+  );
+};
+
+export default {
+  name,
+  description,
+  annotations,
+  inputSchema: params.shape,
+  execute,
+  register,
+};

--- a/src/tools/llm-context/params.ts
+++ b/src/tools/llm-context/params.ts
@@ -1,0 +1,177 @@
+import { z } from 'zod';
+
+export const params = z.object({
+  query: z
+    .string()
+    .max(400)
+    .refine((str) => str.split(/\s+/).length <= 50, 'Query cannot exceed 50 words')
+    .describe('Search query (max 400 chars, 50 words)'),
+  country: z
+    .enum([
+      'ALL',
+      'AR',
+      'AU',
+      'AT',
+      'BE',
+      'BR',
+      'CA',
+      'CL',
+      'DK',
+      'FI',
+      'FR',
+      'DE',
+      'HK',
+      'IN',
+      'ID',
+      'IT',
+      'JP',
+      'KR',
+      'MY',
+      'MX',
+      'NL',
+      'NZ',
+      'NO',
+      'CN',
+      'PL',
+      'PT',
+      'PH',
+      'RU',
+      'SA',
+      'ZA',
+      'ES',
+      'SE',
+      'CH',
+      'TW',
+      'TR',
+      'GB',
+      'US',
+    ])
+    .default('US')
+    .describe(
+      'Search query country, where the results come from. The country string is limited to 2 character country codes of supported countries.'
+    )
+    .optional(),
+  search_lang: z
+    .enum([
+      'ar',
+      'eu',
+      'bn',
+      'bg',
+      'ca',
+      'zh-hans',
+      'zh-hant',
+      'hr',
+      'cs',
+      'da',
+      'nl',
+      'en',
+      'en-gb',
+      'et',
+      'fi',
+      'fr',
+      'gl',
+      'de',
+      'gu',
+      'he',
+      'hi',
+      'hu',
+      'is',
+      'it',
+      'jp',
+      'kn',
+      'ko',
+      'lv',
+      'lt',
+      'ms',
+      'ml',
+      'mr',
+      'nb',
+      'pl',
+      'pt-br',
+      'pt-pt',
+      'pa',
+      'ro',
+      'ru',
+      'sr',
+      'sk',
+      'sl',
+      'es',
+      'sv',
+      'ta',
+      'te',
+      'th',
+      'tr',
+      'uk',
+      'vi',
+    ])
+    .default('en')
+    .describe(
+      'Search language preference. The 2 or more character language code for which the search results are provided.'
+    )
+    .optional(),
+  count: z
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe('Number of search results to consider (1-50, default 20)')
+    .optional(),
+  maximum_number_of_urls: z
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe('Maximum number of URLs to extract content from (1-50, default 20)')
+    .optional(),
+  maximum_number_of_tokens: z
+    .int()
+    .min(1024)
+    .max(32768)
+    .default(8192)
+    .describe('Total token budget for the response across all URLs (1024-32768, default 8192)')
+    .optional(),
+  maximum_number_of_snippets: z
+    .int()
+    .min(1)
+    .max(100)
+    .default(50)
+    .describe('Maximum number of text snippets across all results (1-100, default 50)')
+    .optional(),
+  maximum_number_of_tokens_per_url: z
+    .int()
+    .min(512)
+    .max(8192)
+    .default(4096)
+    .describe('Maximum number of tokens to extract per URL (512-8192, default 4096)')
+    .optional(),
+  maximum_number_of_snippets_per_url: z
+    .int()
+    .min(1)
+    .max(100)
+    .default(50)
+    .describe('Maximum number of text snippets per URL (1-100, default 50)')
+    .optional(),
+  context_threshold_mode: z
+    .enum(['strict', 'balanced', 'lenient', 'disabled'])
+    .default('balanced')
+    .describe(
+      "Controls relevance filtering of extracted content. 'strict' returns fewer, highly relevant results. 'balanced' (default) balances relevance and coverage. 'lenient' returns more results with lower relevance threshold. 'disabled' returns all extracted content without filtering."
+    )
+    .optional(),
+  enable_local: z
+    .boolean()
+    .describe(
+      'Whether to enable location-aware results. When not specified, location sensitivity is auto-detected from the query.'
+    )
+    .optional(),
+  goggles: z
+    .array(z.string())
+    .describe(
+      "Goggles act as a custom re-ranking on top of Brave's search index. The parameter supports both a URL where the Goggle is hosted or the definition of the Goggle. For more details, refer to the Goggles repository (i.e., https://github.com/brave/goggles-quickstart)."
+    )
+    .optional(),
+});
+
+export type QueryParams = z.infer<typeof params>;
+
+export default params;

--- a/src/tools/llm-context/types.ts
+++ b/src/tools/llm-context/types.ts
@@ -1,0 +1,61 @@
+export interface LlmContextApiResponse {
+  /** Grounding data containing extracted content from web pages. */
+  grounding: LlmContextGrounding;
+  /** Source metadata keyed by URL. */
+  sources: Record<string, LlmContextSource>;
+}
+
+export interface LlmContextGrounding {
+  /** A list of generic grounding results with extracted content. */
+  generic: LlmContextGroundingEntry[];
+  /** Point of interest data for location-sensitive queries. */
+  poi: LlmContextPoi | null;
+  /** Map results for location-sensitive queries. */
+  map: LlmContextMapEntry[];
+}
+
+export interface LlmContextGroundingEntry {
+  /** The source URL of the grounding result. */
+  url: string;
+  /** The title of the source page. */
+  title: string;
+  /** Extracted text snippets relevant to the query. */
+  snippets: string[];
+}
+
+export interface LlmContextPoi {
+  /** The name of the point of interest. */
+  name?: string;
+  /** The address of the point of interest. */
+  address?: string;
+  /** The phone number of the point of interest. */
+  phone?: string;
+  /** The rating of the point of interest. */
+  rating?: number;
+  /** The number of reviews for the point of interest. */
+  review_count?: number;
+  /** The price range of the point of interest. */
+  price_range?: string;
+}
+
+export interface LlmContextMapEntry {
+  /** The URL associated with the map result. */
+  url?: string;
+  /** The title of the map result. */
+  title?: string;
+}
+
+export interface LlmContextSource {
+  /** The title of the source page. */
+  title: string;
+  /** The hostname of the source. */
+  hostname: string;
+  /** Modification date information as an array of date representations. */
+  age: string[] | null;
+}
+
+export type FormattedLlmContextResults = {
+  url: string;
+  title: string;
+  snippets: string[];
+}[];


### PR DESCRIPTION
## Summary

- Adds a new `brave_llm_context` tool that integrates with Brave's [LLM Context API](https://api-dashboard.search.brave.com/documentation/services/llm-context) (`/res/v1/llm/context`), [announced Feb 12, 2026](https://brave.com/blog/most-powerful-search-api-for-ai/)
- Returns pre-extracted, LLM-optimized content (markdown text, structured data, code blocks, forum discussions, YouTube captions) rather than URLs and snippets
- Complements `brave_web_search` — use this tool when you need actual page content for grounding LLM responses
- Follows the existing tool pattern exactly: `src/tools/llm-context/` with `index.ts`, `params.ts`, and `types.ts`

### New tool parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `query` | string (required) | — | Search query, 1-400 chars, max 50 words |
| `country` | string | "US" | 2-char country code |
| `search_lang` | string | "en" | Language preference |
| `count` | int | 20 | Results to consider (1-50) |
| `maximum_number_of_urls` | int | 20 | Max URLs to extract (1-50) |
| `maximum_number_of_tokens` | int | 8192 | Total token budget (1024-32768) |
| `maximum_number_of_snippets` | int | 50 | Snippets across results (1-100) |
| `maximum_number_of_tokens_per_url` | int | 4096 | Per-URL token limit (512-8192) |
| `maximum_number_of_snippets_per_url` | int | 50 | Per-URL snippets (1-100) |
| `context_threshold_mode` | string | "balanced" | Relevance filtering mode |
| `enable_local` | boolean | — | Location-aware results |
| `goggles` | array | — | Custom re-ranking |

### Files changed

- **New:** `src/tools/llm-context/index.ts`, `params.ts`, `types.ts`
- **Modified:** `src/BraveAPI/index.ts` (path map), `src/BraveAPI/types.ts` (endpoint types), `src/tools/index.ts` (registry)
- **Updated:** `README.md` (tool documentation)

## Test plan

- [x] `npm run build` — TypeScript compiles without errors
- [x] `npm run format:check` — Prettier passes
- [ ] Manual test via MCP Inspector with a valid API key on Search plan or higher

🤖 Generated with [Claude Code](https://claude.com/claude-code)