### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Options:
   --stateless  <boolean>      HTTP Stateless flag
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/brave-brave-search-mcp-server).
+
 ## Installation
 
 ### Installing via Smithery


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/brave-brave-search-mcp-server)