### PR TITLE
feat(config): support reading Brave API key from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Retrieves pre-extracted web content optimized for AI agents, LLM grounding, and 
 
 The server supports the following environment variables:
 
-- `BRAVE_API_KEY`: Your Brave Search API key (required)
+- `BRAVE_API_KEY`: Your Brave Search API key (required, unless `BRAVE_API_KEY_FILE` is set)
+- `BRAVE_API_KEY_FILE`: Path to a file containing the Brave Search API key. When set, the key is read from this file instead of `BRAVE_API_KEY`. Useful for Docker secrets and similar mounted-secret setups.
 - `BRAVE_MCP_TRANSPORT`: Transport mode ("http" or "stdio", default: "stdio")
 - `BRAVE_MCP_PORT`: HTTP server port (default: 8000)
 - `BRAVE_MCP_HOST`: HTTP server host (default: "0.0.0.0")
@@ -184,8 +185,9 @@ The server supports the following environment variables:
 node dist/index.js [options]
 
 Options:
-  --brave-api-key <string>    Brave API key
-  --transport <stdio|http>    Transport type (default: stdio)
+  --brave-api-key <string>       Brave API key
+  --brave-api-key-file <path>    Path to a file containing the Brave API key (useful for Docker secrets). Takes precedence over --brave-api-key when set.
+  --transport <stdio|http>       Transport type (default: stdio)
   --port <number>             HTTP server port (default: 8080)
   --host <string>             HTTP server host (default: 0.0.0.0)
   --logging-level <string>    Desired logging level (one of _debug_, _info_, _notice_, _warning_, _error_, _critical_, _alert_, or _emergency_)

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,29 @@
+import fs from 'node:fs';
 import { LoggingLevel, LoggingLevelSchema } from '@modelcontextprotocol/sdk/types.js';
 import { Command } from 'commander';
 import dotenv from 'dotenv';
 import tools from './tools/index.js';
 
 dotenv.config({ debug: false, quiet: true });
+
+/**
+ * Reads the Brave Search API key from a file. Used to support Docker
+ * secrets and similar setups where mounting a file is preferred over
+ * passing the key via an environment variable or CLI argument.
+ *
+ * Returns an empty string if `filePath` is empty/undefined. Throws if the
+ * file is set but cannot be read, so the user gets a clear failure
+ * instead of a silently empty key.
+ */
+function readApiKeyFromFile(filePath: string | undefined | null): string {
+  if (!filePath) return '';
+  try {
+    return fs.readFileSync(filePath, 'utf8').trim();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read Brave API key from "${filePath}": ${message}`);
+  }
+}
 
 function parseToolNameList(value: string | string[] | undefined | null): string[] {
   if (value == null) return [];
@@ -47,6 +67,12 @@ export function isToolPermittedByUser(toolName: string): boolean {
 export function getOptions(): Configuration | false {
   const program = new Command()
     .option('--brave-api-key <string>', 'Brave API key', process.env.BRAVE_API_KEY ?? '')
+    .option(
+      '--brave-api-key-file <path>',
+      'Path to a file containing the Brave API key (useful for Docker secrets). ' +
+        'Takes precedence over --brave-api-key when set.',
+      process.env.BRAVE_API_KEY_FILE ?? ''
+    )
     .option('--logging-level <string>', 'Logging level', process.env.BRAVE_MCP_LOG_LEVEL ?? 'info')
     .option(
       '--transport <stdio|http>',
@@ -83,6 +109,18 @@ export function getOptions(): Configuration | false {
 
   const options = program.opts();
   const toolNames = Object.values(tools).map((tool) => tool.name);
+
+  // Resolve the API key: when --brave-api-key-file (or BRAVE_API_KEY_FILE)
+  // is set, read the key from that file. This lets users mount the key as
+  // a Docker secret instead of exposing it through an env var or CLI arg.
+  if (options.braveApiKeyFile) {
+    try {
+      options.braveApiKey = readApiKeyFromFile(options.braveApiKeyFile);
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      return false;
+    }
+  }
 
   // Validate tool inclusion configuration
   const enabledTools = parseToolNameList(options.enabledTools);


### PR DESCRIPTION
Closes #294.

Adds a `BRAVE_API_KEY_FILE` env var and a matching `--brave-api-key-file` CLI option that read the API key from a file instead of from an env var or process argument. When set, this source takes precedence over `BRAVE_API_KEY` / `--brave-api-key`.

The motivation (per the issue) is Docker secrets and similar mounted-secret setups, where the key is dropped at a fixed path (`/run/secrets/...`) rather than passed through `-e` or as a flag. This follows the `_FILE`-suffixed pattern that several common images (Postgres, MariaDB, Redis, MySQL) already implement, so it should feel familiar in Compose/Swarm files.

Behavior:
- If the file path is set but cannot be read, the error message includes the path and the underlying reason, and the process exits via the existing `console.error` + `return false` flow (no silent empty key).
- If both `BRAVE_API_KEY` and `BRAVE_API_KEY_FILE` are set, the file takes precedence. Same goes for `--brave-api-key-file` vs `--brave-api-key`.
- The file is `.trim()`'d so a trailing newline (very common for files written by humans / templated) does not corrupt the key.

The README has been updated to document the new env var and CLI flag.

### Manual verification

Built with `npm run build` (TypeScript compiles cleanly) and `npx prettier --check src/**/*.ts` passes. Manual smoke tests against the built CLI:

- `BRAVE_API_KEY_FILE=/tmp/key.txt node dist/index.js --transport stdio` — reads the key from the file (no "API key required" error).
- `--brave-api-key-file=/tmp/key.txt` — same, via CLI.
- `BRAVE_API_KEY=ignored BRAVE_API_KEY_FILE=/tmp/key.txt ...` — file wins, key from env is dropped.
- `--brave-api-key-file=/tmp/missing.txt` — exits with `Error: Failed to read Brave API key from "/tmp/missing.txt": ENOENT: no such file or directory`.
- `node dist/index.js --help` — the new flag appears with its description.