### PR TITLE
Harden HTTP transport: enable DNS-rebinding protection and default to loopback bind

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -25,18 +25,23 @@ type Configuration = {
   enabledTools: string[];
   disabledTools: string[];
   stateless: boolean;
+  allowedHosts: string[];
 };
 
 const state: Configuration & { ready: boolean } = {
   transport: 'stdio',
   port: 8080,
-  host: '0.0.0.0',
+  // Bind to loopback by default. The HTTP transport is unauthenticated, so binding to
+  // 0.0.0.0 exposes it to other hosts on the network. Deployments that intentionally
+  // expose it (e.g. behind a gateway) can set --host/BRAVE_MCP_HOST explicitly.
+  host: '127.0.0.1',
   braveApiKey: process.env.BRAVE_API_KEY ?? '',
   loggingLevel: 'info',
   ready: false,
   enabledTools: [],
   disabledTools: [],
   stateless: false,
+  allowedHosts: [],
 };
 
 export function isToolPermittedByUser(toolName: string): boolean {
@@ -77,7 +82,15 @@ export function getOptions(): Configuration | false {
     .option(
       '--host <string>',
       'desired host for HTTP transport',
-      process.env.BRAVE_MCP_HOST ?? '0.0.0.0'
+      process.env.BRAVE_MCP_HOST ?? '127.0.0.1'
+    )
+    .option(
+      '--allowed-hosts <hosts...>',
+      'Host header values accepted by the HTTP transport (DNS-rebinding protection). ' +
+        'Defaults to the bind host plus loopback; set this for proxied/remote deployments.',
+      process.env.BRAVE_MCP_ALLOWED_HOSTS?.trim()
+        .split(/[\s,]+/)
+        .filter(Boolean) ?? []
     )
     .option(
       '--stateless <boolean>',
@@ -158,6 +171,19 @@ export function getOptions(): Configuration | false {
       console.error('Error: --host is required');
       return false;
     }
+
+    // Build the Host-header allowlist (DNS-rebinding protection). Always include the
+    // bind host and loopback so the documented local usage works out of the box; any
+    // additional names (e.g. a public domain behind a gateway) come from --allowed-hosts.
+    const configuredAllowedHosts = parseToolNameList(options.allowedHosts);
+    options.allowedHosts = [
+      ...new Set([
+        `${options.host}:${port}`,
+        `127.0.0.1:${port}`,
+        `localhost:${port}`,
+        ...configuredAllowedHosts,
+      ]),
+    ];
   }
 
   // Normalize stateless to boolean (CLI passes it as string)
@@ -173,6 +199,7 @@ export function getOptions(): Configuration | false {
   state.enabledTools = enabledTools;
   state.disabledTools = disabledTools;
   state.stateless = options.stateless;
+  state.allowedHosts = Array.isArray(options.allowedHosts) ? options.allowedHosts : [];
   state.ready = true;
 
   return options as Configuration;

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -30,6 +30,8 @@ const getTransport = async (request: Request): Promise<StreamableHTTPServerTrans
   if (!sessionId && isListToolsRequest(request.body)) {
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
+      enableDnsRebindingProtection: true,
+      allowedHosts: config.allowedHosts,
     });
 
     const mcpServer = createMcpServer();
@@ -43,11 +45,15 @@ const getTransport = async (request: Request): Promise<StreamableHTTPServerTrans
     // Some contexts (e.g. AgentCore) may prefer or require a stateless transport
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
+      enableDnsRebindingProtection: true,
+      allowedHosts: config.allowedHosts,
     });
   } else {
     // Otherwise, start a new transport/session
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
+      enableDnsRebindingProtection: true,
+      allowedHosts: config.allowedHosts,
       onsessioninitialized: (sessionId) => {
         transports.set(sessionId, transport);
       },


### PR DESCRIPTION
## Harden the HTTP transport: enable DNS-rebinding protection and default to a loopback bind

### Background

When the server runs with `--transport http`, the `/mcp` endpoint is unauthenticated and every tool call is proxied to `api.search.brave.com` with the configured `X-Subscription-Token` (`src/BraveAPI/index.ts`). So any party that can reach the listener can invoke search tools under the operator's Brave Search API key.

Two things make that reachable in the current defaults:

1. **No `Host`/`Origin` validation.** The three `StreamableHTTPServerTransport` constructions in `src/protocols/http.ts` don't set `enableDnsRebindingProtection`/`allowedHosts`. Without it, a website the operator visits can use **DNS rebinding** to point its hostname at `127.0.0.1` and `POST` to `http://localhost:<port>/mcp` — the browser request is accepted. This is the exact attack `enableDnsRebindingProtection` exists to stop.
2. **`0.0.0.0` bind by default** (`src/config.ts`). With the listener on all interfaces, any other host on the network (or a co-located process/container) can reach `/mcp` directly.

The pinned `@modelcontextprotocol/sdk@1.29.0` already exposes `enableDnsRebindingProtection` / `allowedHosts` / `allowedOrigins`; they just weren't wired up. This aligns with the MCP transport-security guidance (validate `Origin`, bind to localhost, and authenticate local HTTP servers).

### Change

- `src/protocols/http.ts`: set `enableDnsRebindingProtection: true` and `allowedHosts: config.allowedHosts` on all three transports.
- `src/config.ts`: default the bind host to `127.0.0.1`, and build a `Host` allowlist that defaults to the bind host plus loopback. A new `--allowed-hosts` flag / `BRAVE_MCP_ALLOWED_HOSTS` env lets proxied/remote deployments (a gateway, or the stateless AgentCore path) add their public host.

Default/local usage is unaffected — loopback hosts are allowed. Deployments that intentionally expose the server keep doing so by setting `--host`/`BRAVE_MCP_HOST` and `--allowed-hosts`/`BRAVE_MCP_ALLOWED_HOSTS`.

### Verification (before / after)

`tools/list` POST to `/mcp` with a spoofed `Host` header vs. the legitimate loopback host:

| `Host` header | before (`main`) | after (this PR) |
|---|---|---|
| `attacker.example` (DNS-rebind / cross-host) | `HTTP 200` (accepted) | **`HTTP 403` (rejected)** |
| `127.0.0.1:<port>` (legitimate) | `HTTP 200` | `HTTP 200` |

Repro:

```sh
BRAVE_API_KEY=<key> node dist/index.js --transport http --port 8077 &
curl -s -o /dev/null -w "%{http_code}\n" \
  -H "Host: attacker.example" \
  -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
  http://127.0.0.1:8077/mcp
```

### References
- MCP Transport Security (Origin validation / bind localhost / authentication for local Streamable-HTTP servers).
- `@modelcontextprotocol/sdk` Streamable HTTP options: `enableDnsRebindingProtection`, `allowedHosts`, `allowedOrigins`.
