### PR TITLE
Bound JSON-RPC batch fan-out and stop retrying permanent Summarizer failures

### DIFF
--- a/src/BraveAPI/index.ts
+++ b/src/BraveAPI/index.ts
@@ -2,6 +2,21 @@ import type { Endpoints } from './types.js';
 import config from '../config.js';
 import { stringify } from '../utils.js';
 
+/**
+ * Error thrown when the Brave Search API returns a non-2xx response. Carries
+ * the HTTP status so callers can distinguish transient failures (429, 5xx)
+ * from deterministic ones (401, 403, 422) that will not change on retry.
+ */
+export class BraveApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'BraveApiError';
+    this.status = status;
+  }
+}
+
 const typeToPathMap: Record<keyof Endpoints, string> = {
   images: '/res/v1/images/search',
   localPois: '/res/v1/local/pois',
@@ -128,7 +143,7 @@ async function issueRequest<T extends keyof Endpoints>(
     }
 
     // TODO (Sampson): Setup proper error handling, updating state, etc.
-    throw new Error(errorMessage);
+    throw new BraveApiError(response.status, errorMessage);
   }
 
   // Return Response

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,26 @@ export const RATE_LIMIT = {
   perSecond: 1,
   perMonth: 15000,
 } as const;
+
+/**
+ * Limits applied at the HTTP edge, before a request reaches the MCP SDK.
+ *
+ * `maxBatchSize` bounds how many tool calls a single HTTP request can dispatch.
+ * `maxBodySize` is an explicit parser cap rather than an inherited default, so
+ * the bound is a stated decision instead of a side effect of body-parser's
+ * 100kb default.
+ */
+export const HTTP_LIMITS = {
+  maxBatchSize: 10,
+  maxBodySize: '64kb',
+} as const;
+
+/**
+ * Polling behavior for the (async) Summarizer endpoint. `pollIntervalMs` is the
+ * delay between attempts; `pollAttempts` is the hard ceiling on outbound
+ * requests per tool call.
+ */
+export const SUMMARIZER_POLL = {
+  pollIntervalMs: 50,
+  pollAttempts: 20,
+} as const;

--- a/src/protocols/batch.test.ts
+++ b/src/protocols/batch.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { after, before, describe, it } from 'node:test';
+import { HTTP_LIMITS } from '../constants.js';
+import httpServer from './http.js';
+
+const message = (id: number) => ({
+  jsonrpc: '2.0',
+  id,
+  method: 'tools/call',
+  params: { name: 'brave_summarizer', arguments: { key: 'x' } },
+});
+
+// Minimal well-formed messages, so a large batch stays under the body limit and
+// is stopped by the batch cap rather than by the parser.
+const minimal = (id: number) => ({ jsonrpc: '2.0', id, method: 'tools/call' });
+
+const batch = (size: number, build: (id: number) => Record<string, unknown> = message) =>
+  Array.from({ length: size }, (_, i) => build(i));
+
+describe('http JSON-RPC batch limits', () => {
+  let server: Server;
+  let baseUrl: string;
+
+  const post = (body: unknown) =>
+    fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(body),
+    });
+
+  before(async () => {
+    const app = httpServer.createApp();
+    server = app.listen(0);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    );
+  });
+
+  it('rejects a batch larger than the limit with 400 and a JSON-RPC error', async () => {
+    const res = await post(batch(HTTP_LIMITS.maxBatchSize + 1));
+    const body = await res.json();
+
+    assert.equal(res.status, 400);
+    assert.equal(body.jsonrpc, '2.0');
+    assert.equal(body.id, null);
+    assert.equal(body.error.code, -32600);
+  });
+
+  it('rejects the 931-message batch from the amplification report', async () => {
+    const body = batch(931, minimal);
+    // Confirm the batch cap is doing the work here, not the parser limit.
+    assert.ok(Buffer.byteLength(JSON.stringify(body)) < 64 * 1024);
+
+    const res = await post(body);
+    const json = await res.json();
+
+    assert.equal(res.status, 400);
+    assert.match(json.error.message, /Batch size exceeds/);
+  });
+
+  it('passes a batch at exactly the limit through to the MCP SDK', async () => {
+    const res = await post(batch(HTTP_LIMITS.maxBatchSize));
+    const json = await res.json();
+
+    // The SDK rejects a session-less tools/call on its own terms; what matters
+    // is that the rejection is not ours.
+    assert.doesNotMatch(JSON.stringify(json), /Batch size exceeds/);
+  });
+
+  it('leaves single (non-array) messages untouched', async () => {
+    const res = await post({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    assert.notEqual(res.status, 400);
+  });
+
+  it('rejects a body over the configured parser limit with 413', async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'x',
+        params: { q: 'a'.repeat(70_000) },
+      }),
+    });
+
+    assert.equal(res.status, 413);
+  });
+});

--- a/src/protocols/batch.ts
+++ b/src/protocols/batch.ts
@@ -1,0 +1,30 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+// 400 with a JSON-RPC error and no id, per the MCP Streamable HTTP spec.
+const sendBadRequest = (res: Response, message: string): void => {
+  res.status(400).json({ jsonrpc: '2.0', error: { code: -32600, message }, id: null });
+};
+
+/**
+ * Builds Express middleware that caps the number of messages in a JSON-RPC
+ * batch before the request reaches the MCP SDK.
+ *
+ * The SDK accepts batch arrays of any length, and every message in a batch can
+ * dispatch its own tool call, so one accepted HTTP request can fan out into an
+ * unbounded number of outbound Brave Search API calls. Capping the array length
+ * bounds that fan-out at the edge, independent of body size.
+ *
+ * Non-array bodies (the common single-message case) pass straight through.
+ */
+export const createBatchLimitGuard = (options: { maxBatchSize: number }): RequestHandler => {
+  const { maxBatchSize } = options;
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (Array.isArray(req.body) && req.body.length > maxBatchSize) {
+      sendBadRequest(res, `Batch size exceeds the limit of ${maxBatchSize} messages`);
+      return;
+    }
+
+    next();
+  };
+};

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -5,6 +5,8 @@ import createMcpServer from '../server.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ListToolsRequest, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { createDnsRebindingGuard } from './rebinding.js';
+import { createBatchLimitGuard } from './batch.js';
+import { HTTP_LIMITS } from '../constants.js';
 
 const yieldGenericServerError = (res: Response) => {
   res.status(500).json({
@@ -71,7 +73,9 @@ const createApp = () => {
     })
   );
 
-  app.use('/mcp', express.json());
+  app.use('/mcp', express.json({ limit: HTTP_LIMITS.maxBodySize }));
+
+  app.use('/mcp', createBatchLimitGuard({ maxBatchSize: HTTP_LIMITS.maxBatchSize }));
 
   app.all('/mcp', async (req: Request, res: Response) => {
     try {

--- a/src/tools/summarizer/index.test.ts
+++ b/src/tools/summarizer/index.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+import API, { BraveApiError } from '../../BraveAPI/index.js';
+import { SUMMARIZER_POLL } from '../../constants.js';
+import { execute, isRetryableError } from './index.js';
+
+const params = { key: 'test-key' } as Parameters<typeof execute>[0];
+
+describe('summarizer retry classification', () => {
+  it('treats throttling and upstream failures as retryable', () => {
+    assert.equal(isRetryableError(new BraveApiError(429, 'Too Many Requests')), true);
+    assert.equal(isRetryableError(new BraveApiError(500, 'Internal Server Error')), true);
+    assert.equal(isRetryableError(new BraveApiError(503, 'Service Unavailable')), true);
+  });
+
+  it('treats deterministic client errors as permanent', () => {
+    assert.equal(isRetryableError(new BraveApiError(401, 'Unauthorized')), false);
+    assert.equal(isRetryableError(new BraveApiError(403, 'Forbidden')), false);
+    assert.equal(isRetryableError(new BraveApiError(422, 'Unprocessable Entity')), false);
+  });
+
+  it('treats errors without a status as transient', () => {
+    assert.equal(isRetryableError(new Error('socket hang up')), true);
+  });
+});
+
+describe('summarizer polling', () => {
+  afterEach(() => mock.restoreAll());
+
+  it('issues one request -- not twenty -- when the API key is invalid', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => {
+      throw new BraveApiError(401, 'Unauthorized');
+    });
+
+    const result = await execute(params);
+
+    assert.equal(issueRequest.mock.callCount(), 1);
+    assert.equal(result.isError, true);
+  });
+
+  it('still exhausts its attempts on retryable failures', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => {
+      throw new BraveApiError(503, 'Service Unavailable');
+    });
+
+    const result = await execute(params);
+
+    assert.equal(issueRequest.mock.callCount(), SUMMARIZER_POLL.pollAttempts);
+    assert.equal(result.isError, true);
+  });
+
+  it('paces polls when the summary is not yet complete', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => ({ status: 'pending' }));
+
+    const start = Date.now();
+    await execute(params);
+    const elapsed = Date.now() - start;
+
+    // Nineteen inter-attempt delays. The previous implementation slept only on
+    // the error path, so this case ran all twenty polls back to back.
+    const expected = (SUMMARIZER_POLL.pollAttempts - 1) * SUMMARIZER_POLL.pollIntervalMs;
+
+    assert.equal(issueRequest.mock.callCount(), SUMMARIZER_POLL.pollAttempts);
+    assert.ok(elapsed >= expected * 0.8, `expected pacing of ~${expected}ms, saw ${elapsed}ms`);
+  });
+
+  it('returns the summary as soon as one completes', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => ({
+      status: 'complete',
+      summary: [{ type: 'token', data: 'hello world' }],
+    }));
+
+    const result = await execute(params);
+
+    assert.equal(issueRequest.mock.callCount(), 1);
+    assert.equal(result.isError, false);
+
+    const [block] = result.content;
+    assert.equal(block.type, 'text');
+    assert.equal(block.type === 'text' ? block.text : undefined, 'hello world');
+  });
+
+  it('stops polling when the caller cancels', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => ({ status: 'pending' }));
+    const controller = new AbortController();
+
+    setTimeout(() => controller.abort(), SUMMARIZER_POLL.pollIntervalMs * 3);
+    const result = await execute(params, { signal: controller.signal });
+
+    assert.ok(issueRequest.mock.callCount() < SUMMARIZER_POLL.pollAttempts);
+    assert.equal(result.isError, true);
+  });
+});

--- a/src/tools/summarizer/index.ts
+++ b/src/tools/summarizer/index.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { summarizerQueryParams, type SummarizerQueryParams } from './params.js';
-import API from '../../BraveAPI/index.js';
+import API, { BraveApiError } from '../../BraveAPI/index.js';
+import { SUMMARIZER_POLL } from '../../constants.js';
 import { type SummarizerSearchApiResponse } from './types.js';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -26,11 +27,11 @@ export const description = `
     Requirements: Must first perform a web search using brave_web_search with summary=true parameter. Requires a Pro AI subscription to access the summarizer functionality.
 `.trim();
 
-export const execute = async (params: SummarizerQueryParams) => {
+export const execute = async (params: SummarizerQueryParams, extra?: { signal?: AbortSignal }) => {
   const response: CallToolResult = { content: [], isError: false };
 
   try {
-    const { summary } = await pollForSummary(params);
+    const { summary } = await pollForSummary(params, undefined, undefined, extra?.signal);
 
     if (!summary || summary.length === 0) {
       response.isError = true;
@@ -80,31 +81,74 @@ export const register = (mcpServer: McpServer) => {
   );
 };
 
+/**
+ * A summary that is still being generated is worth waiting for; a request the
+ * API has already rejected is not. Retry only on throttling (429) and upstream
+ * failures (5xx). Every other status -- an invalid or unsubscribed key (401,
+ * 403), a malformed request (422) -- is deterministic and will return the same
+ * result on every attempt, so retrying it only multiplies outbound requests.
+ *
+ * Errors that are not BraveApiError (network faults, JSON parse failures) have
+ * no status to judge and are treated as transient.
+ */
+export const isRetryableError = (error: unknown): boolean => {
+  if (!(error instanceof BraveApiError)) return true;
+  return error.status === 429 || error.status >= 500;
+};
+
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('Aborted'));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error('Aborted'));
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+
 const pollForSummary = async (
   params: SummarizerQueryParams,
-  pollInterval: number = 50,
-  attempts: number = 20
+  pollInterval: number = SUMMARIZER_POLL.pollIntervalMs,
+  attempts: number = SUMMARIZER_POLL.pollAttempts,
+  signal?: AbortSignal
 ): Promise<SummarizerSearchApiResponse> => {
-  let result: SummarizerSearchApiResponse | null = null;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    // Wait between attempts, not before the first one. The previous
+    // implementation only slept on the error path, so a well-formed response
+    // that was not yet 'complete' re-polled immediately -- issuing all
+    // remaining attempts back to back with no delay at all.
+    if (attempt > 0) {
+      await sleep(pollInterval, signal);
+    }
 
-  while (!result && attempts > 0) {
+    if (signal?.aborted) {
+      throw signal.reason ?? new Error('Aborted');
+    }
+
     try {
       const response = await API.issueRequest<'summarizer'>('summarizer', params);
       if (response.status === 'complete') {
-        result = response;
+        return response;
       }
     } catch (error) {
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      // Stop immediately on a failure that repeating cannot resolve.
+      if (!isRetryableError(error)) {
+        throw error;
+      }
     }
-
-    attempts--;
   }
 
-  if (!result) {
-    throw new Error('Summarizer summary could not be retrieved after multiple attempts.');
-  }
-
-  return result;
+  throw new Error('Summarizer summary could not be retrieved after multiple attempts.');
 };
 
 export default {


### PR DESCRIPTION
<html><head></head><body><h1>Bound JSON-RPC batch fan-out and stop retrying permanent Summarizer failures</h1>
<p>Closes #277.</p>
<p>Today a single accepted POST to <code>/mcp</code> can dispatch an unbounded number of tool
calls, and each <code>brave_summarizer</code> call can issue up to 20 outbound Brave Search
API requests. The two compound: one HTTP request can consume a large share of a
monthly quota.</p>
<p>This bounds the fan-out at both ends. It does not add a rate limiter — that
needs a decision about scope and durability that belongs to the maintainers
(see "Deliberately out of scope").</p>
<h2>Changes</h2>
<p><strong><code>src/protocols/batch.ts</code> (new) — cap JSON-RPC batch length.</strong>
Middleware in the same shape as <code>createDnsRebindingGuard</code>, applied after the
JSON parser and before the MCP SDK. Arrays longer than <code>HTTP_LIMITS.maxBatchSize</code>
get a 400 with a JSON-RPC error and a null id, per the Streamable HTTP spec.
Non-array bodies — the common single-message case — pass through untouched.</p>
<p><strong><code>src/protocols/http.ts</code> — state the body limit explicitly.</strong>
<code>express.json()</code> was inheriting body-parser's 100kb default. It now declares
<code>HTTP_LIMITS.maxBodySize</code> (64kb) so the bound is a decision rather than a side
effect. This is defense in depth; the batch cap is what actually bounds fan-out.</p>
<p><strong><code>src/BraveAPI/index.ts</code> — <code>BraveApiError</code> carries the HTTP status.</strong>
<code>issueRequest</code> threw a bare <code>Error</code> with the status interpolated into the
message, so callers had no way to tell a 401 from a 503 without parsing strings.
<code>BraveApiError extends Error</code> with the same message, so existing <code>catch</code> blocks
are unaffected.</p>
<p><strong><code>src/tools/summarizer/index.ts</code> — retry only what retrying can fix.</strong>
The poll loop now stops immediately on deterministic failures (401, 403, 422)
and keeps retrying only 429 and 5xx. An invalid key costs one request instead of
twenty. Errors with no status (network faults, parse failures) are still treated
as transient. The loop also honors the <code>AbortSignal</code> the MCP SDK already passes
to tool handlers, so a cancelled request stops polling.</p>
<h3>One thing #277 didn't catch</h3>
<p>The report describes the loop as polling "up to 20 times at 50ms intervals."
That was only true on the error path. The <code>await</code> on <code>pollInterval</code> sat inside
the <code>catch</code> block, so a well-formed response that wasn't yet <code>status: 'complete'</code>
re-polled with <strong>no delay at all</strong> — all remaining attempts fired back to back
as fast as the network allowed. The delay now sits between attempts regardless
of outcome. There's a regression test for it.</p>
<h2>Effect</h2>

  | before | after
-- | -- | --
max messages per request | 931 (body-limit bound) | 10
requests per summarizer call, invalid key | 20 | 1
worst case per HTTP request | 18,620 | 200
pacing when summary is pending | none | 50ms between polls


<h2>Tests</h2>
<p><code>src/protocols/batch.test.ts</code> and <code>src/tools/summarizer/index.test.ts</code>, in the
existing <code>node:test</code> style. Includes the 931-message batch from the report,
asserted to stay under the body limit so it proves the batch cap fires on its
own rather than the parser catching it.</p>
<p>64/64 pass; <code>tsc --noEmit</code> and <code>prettier --check</code> clean.</p>
<h2>Deliberately out of scope</h2>
<ul>
<li><strong>The rate limiter.</strong> <code>checkRateLimit()</code> is still commented out in
<code>issueRequest</code>. As written it's process-global with no durable monthly
accounting, so restoring it as-is would be misleading rather than protective.
A real limiter needs a decision on scope (per key? per session?) and whether
state must survive restarts and multiple replicas. Happy to follow up if
there's a direction you'd like. This also overlaps #238.</li>
<li><strong>Exponential backoff.</strong> Left the interval fixed to preserve current latency.
Backoff changes worst-case tool duration and seemed worth deciding separately.</li>
</ul>
<h2>Choosing the constants</h2>
<p>Both live in <code>src/constants.ts</code> as <code>HTTP_LIMITS</code>. <code>maxBatchSize: 10</code> is the
value proposed in #277; <code>maxBodySize: '64kb'</code> is well above any legitimate
request these tools take while staying under the inherited default. Both are
one-line changes if you'd rather be more permissive — the security property
holds at any bounded value.</p></body></html>