### PR TITLE
Declare each tool's plan requirement and explain plan mismatches in errors

### DIFF
--- a/src/BraveAPI/index.ts
+++ b/src/BraveAPI/index.ts
@@ -1,6 +1,7 @@
 import type { Endpoints } from './types.js';
 import config from '../config.js';
 import { stringify } from '../utils.js';
+import { describeAccessFailure, ENDPOINT_PLANS, isAccessFailure, type PlanId } from '../plans.js';
 
 /**
  * Error thrown when the Brave Search API returns a non-2xx response. Carries
@@ -9,11 +10,15 @@ import { stringify } from '../utils.js';
  */
 export class BraveApiError extends Error {
   readonly status: number;
+  readonly endpoint: keyof Endpoints;
+  readonly requiredPlan: PlanId;
 
-  constructor(status: number, message: string) {
+  constructor(status: number, endpoint: keyof Endpoints, message: string) {
     super(message);
     this.name = 'BraveApiError';
     this.status = status;
+    this.endpoint = endpoint;
+    this.requiredPlan = ENDPOINT_PLANS[endpoint];
   }
 }
 
@@ -142,8 +147,14 @@ async function issueRequest<T extends keyof Endpoints>(
       errorMessage += `\n${await response.text()}`;
     }
 
+    // A 401/403/422 is usually a plan mismatch rather than a malformed key.
+    // Say which plan this endpoint needs, so the caller can act on it.
+    if (isAccessFailure(response.status)) {
+      errorMessage += `\n\n${describeAccessFailure(endpoint)}`;
+    }
+
     // TODO (Sampson): Setup proper error handling, updating state, etc.
-    throw new BraveApiError(response.status, errorMessage);
+    throw new BraveApiError(response.status, endpoint, errorMessage);
   }
 
   // Return Response

--- a/src/BraveAPI/index.ts
+++ b/src/BraveAPI/index.ts
@@ -2,6 +2,21 @@ import type { Endpoints } from './types.js';
 import config from '../config.js';
 import { stringify } from '../utils.js';
 
+/**
+ * Error thrown when the Brave Search API returns a non-2xx response. Carries
+ * the HTTP status so callers can distinguish transient failures (429, 5xx)
+ * from deterministic ones (401, 403, 422) that will not change on retry.
+ */
+export class BraveApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'BraveApiError';
+    this.status = status;
+  }
+}
+
 const typeToPathMap: Record<keyof Endpoints, string> = {
   images: '/res/v1/images/search',
   localPois: '/res/v1/local/pois',
@@ -128,7 +143,7 @@ async function issueRequest<T extends keyof Endpoints>(
     }
 
     // TODO (Sampson): Setup proper error handling, updating state, etc.
-    throw new Error(errorMessage);
+    throw new BraveApiError(response.status, errorMessage);
   }
 
   // Return Response

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,26 @@ export const RATE_LIMIT = {
   perSecond: 1,
   perMonth: 15000,
 } as const;
+
+/**
+ * Limits applied at the HTTP edge, before a request reaches the MCP SDK.
+ *
+ * `maxBatchSize` bounds how many tool calls a single HTTP request can dispatch.
+ * `maxBodySize` is an explicit parser cap rather than an inherited default, so
+ * the bound is a stated decision instead of a side effect of body-parser's
+ * 100kb default.
+ */
+export const HTTP_LIMITS = {
+  maxBatchSize: 10,
+  maxBodySize: '64kb',
+} as const;
+
+/**
+ * Polling behavior for the (async) Summarizer endpoint. `pollIntervalMs` is the
+ * delay between attempts; `pollAttempts` is the hard ceiling on outbound
+ * requests per tool call.
+ */
+export const SUMMARIZER_POLL = {
+  pollIntervalMs: 50,
+  pollAttempts: 20,
+} as const;

--- a/src/plans.test.ts
+++ b/src/plans.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { Endpoints } from './BraveAPI/types.js';
+import tools from './tools/index.js';
+import {
+  describeAccessFailure,
+  describePlanRequirement,
+  ENDPOINT_PLANS,
+  isAccessFailure,
+  PLANS,
+  PLAN_DASHBOARD_URL,
+} from './plans.js';
+
+describe('plan registry', () => {
+  it('assigns every endpoint a plan that exists', () => {
+    for (const [endpoint, planId] of Object.entries(ENDPOINT_PLANS)) {
+      assert.ok(PLANS[planId], `${endpoint} maps to unknown plan '${planId}'`);
+    }
+  });
+
+  it('covers every endpoint the API client can reach', () => {
+    // Mirrors the keys of Endpoints; a new endpoint without a plan is a bug.
+    const endpoints: (keyof Endpoints)[] = [
+      'images',
+      'localPois',
+      'localDescriptions',
+      'news',
+      'videos',
+      'web',
+      'summarizer',
+      'llmContext',
+      'placeSearch',
+    ];
+
+    for (const endpoint of endpoints) {
+      assert.ok(ENDPOINT_PLANS[endpoint], `${endpoint} has no plan assigned`);
+    }
+  });
+
+  it('separates search endpoints from the summarizer', () => {
+    assert.notEqual(ENDPOINT_PLANS.web, ENDPOINT_PLANS.summarizer);
+  });
+});
+
+describe('access failure classification', () => {
+  it('treats entitlement failures as access failures', () => {
+    assert.equal(isAccessFailure(401), true);
+    assert.equal(isAccessFailure(403), true);
+    assert.equal(isAccessFailure(422), true);
+  });
+
+  it('leaves throttling and upstream failures alone', () => {
+    assert.equal(isAccessFailure(429), false);
+    assert.equal(isAccessFailure(500), false);
+    assert.equal(isAccessFailure(200), false);
+  });
+});
+
+describe('plan guidance text', () => {
+  it('names the plan the endpoint needs', () => {
+    assert.match(describePlanRequirement('summarizer'), /Answers/);
+    assert.match(describePlanRequirement('web'), /Search/);
+  });
+
+  it('tells the caller retrying will not help, and where to go', () => {
+    const message = describeAccessFailure('summarizer');
+
+    assert.match(message, /Answers/);
+    assert.match(message, /retrying will not help/);
+    assert.ok(message.includes(PLAN_DASHBOARD_URL));
+  });
+});
+
+describe('tool descriptions', () => {
+  it('state a plan requirement on every registered tool', () => {
+    for (const tool of Object.values(tools)) {
+      assert.match(
+        tool.description,
+        /Requires the Brave Search '.+' plan\./,
+        `${tool.name} does not state its plan requirement`
+      );
+    }
+  });
+});

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1,0 +1,76 @@
+import type { Endpoints } from './BraveAPI/types.js';
+
+export const PLAN_DASHBOARD_URL =
+  'https://api-dashboard.search.brave.com/app/subscriptions/subscribe';
+
+export type PlanId = 'search' | 'searchPro' | 'answers';
+
+/**
+ * Brave sells access as plans, and a subscription token is scoped to the plan
+ * it was issued under. A token that works for /web/search is not guaranteed to
+ * work for /summarizer/search. Naming follows the plan banners in
+ * brave/brave-search-skills.
+ */
+export const PLANS: Record<PlanId, { label: string; note?: string }> = {
+  search: {
+    label: 'Search',
+  },
+  searchPro: {
+    label: 'Search (Pro tier)',
+    note: 'Local and place endpoints are available only on the Pro tiers.',
+  },
+  answers: {
+    label: 'Answers',
+    note: "Referred to as 'Pro AI' elsewhere in the Brave docs.",
+  },
+};
+
+/**
+ * Which plan each endpoint is served under. This is the single place that
+ * knowledge lives; tool descriptions and error messages both read from here so
+ * they cannot drift apart.
+ */
+export const ENDPOINT_PLANS: Record<keyof Endpoints, PlanId> = {
+  web: 'search',
+  images: 'search',
+  videos: 'search',
+  news: 'search',
+  llmContext: 'search',
+  localPois: 'searchPro',
+  localDescriptions: 'searchPro',
+  placeSearch: 'searchPro',
+  summarizer: 'answers',
+};
+
+/**
+ * A one-line statement of what a given endpoint needs, suitable for appending
+ * to an error or embedding in a tool description.
+ */
+export const describePlanRequirement = (endpoint: keyof Endpoints): string => {
+  const plan = PLANS[ENDPOINT_PLANS[endpoint]];
+  const note = plan.note ? ` ${plan.note}` : '';
+  return `Requires the Brave Search '${plan.label}' plan.${note}`;
+};
+
+/**
+ * Guidance appended to authentication and authorization failures.
+ *
+ * A 401/403/422 from Brave is most often a plan mismatch rather than a
+ * malformed key: the token is valid, but it was issued under a plan that does
+ * not include this endpoint. Saying so turns an opaque failure into one the
+ * caller -- increasingly a model rather than a person -- can act on.
+ */
+export const describeAccessFailure = (endpoint: keyof Endpoints): string =>
+  [
+    describePlanRequirement(endpoint),
+    'If your API key is subscribed to a different plan, this request will fail on every attempt; retrying will not help.',
+    `Review or change your plan at ${PLAN_DASHBOARD_URL}`,
+  ].join(' ');
+
+/**
+ * Statuses that indicate the key is valid JSON but not entitled to this
+ * endpoint (or not valid at all). Distinct from 429 and 5xx, which are worth
+ * retrying.
+ */
+export const isAccessFailure = (status: number): boolean =>
+  status === 401 || status === 403 || status === 422;

--- a/src/protocols/batch.test.ts
+++ b/src/protocols/batch.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { after, before, describe, it } from 'node:test';
+import { HTTP_LIMITS } from '../constants.js';
+import httpServer from './http.js';
+
+const message = (id: number) => ({
+  jsonrpc: '2.0',
+  id,
+  method: 'tools/call',
+  params: { name: 'brave_summarizer', arguments: { key: 'x' } },
+});
+
+// Minimal well-formed messages, so a large batch stays under the body limit and
+// is stopped by the batch cap rather than by the parser.
+const minimal = (id: number) => ({ jsonrpc: '2.0', id, method: 'tools/call' });
+
+const batch = (size: number, build: (id: number) => Record<string, unknown> = message) =>
+  Array.from({ length: size }, (_, i) => build(i));
+
+describe('http JSON-RPC batch limits', () => {
+  let server: Server;
+  let baseUrl: string;
+
+  const post = (body: unknown) =>
+    fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(body),
+    });
+
+  before(async () => {
+    const app = httpServer.createApp();
+    server = app.listen(0);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    );
+  });
+
+  it('rejects a batch larger than the limit with 400 and a JSON-RPC error', async () => {
+    const res = await post(batch(HTTP_LIMITS.maxBatchSize + 1));
+    const body = await res.json();
+
+    assert.equal(res.status, 400);
+    assert.equal(body.jsonrpc, '2.0');
+    assert.equal(body.id, null);
+    assert.equal(body.error.code, -32600);
+  });
+
+  it('rejects the 931-message batch from the amplification report', async () => {
+    const body = batch(931, minimal);
+    // Confirm the batch cap is doing the work here, not the parser limit.
+    assert.ok(Buffer.byteLength(JSON.stringify(body)) < 64 * 1024);
+
+    const res = await post(body);
+    const json = await res.json();
+
+    assert.equal(res.status, 400);
+    assert.match(json.error.message, /Batch size exceeds/);
+  });
+
+  it('passes a batch at exactly the limit through to the MCP SDK', async () => {
+    const res = await post(batch(HTTP_LIMITS.maxBatchSize));
+    const json = await res.json();
+
+    // The SDK rejects a session-less tools/call on its own terms; what matters
+    // is that the rejection is not ours.
+    assert.doesNotMatch(JSON.stringify(json), /Batch size exceeds/);
+  });
+
+  it('leaves single (non-array) messages untouched', async () => {
+    const res = await post({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    assert.notEqual(res.status, 400);
+  });
+
+  it('rejects a body over the configured parser limit with 413', async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'x',
+        params: { q: 'a'.repeat(70_000) },
+      }),
+    });
+
+    assert.equal(res.status, 413);
+  });
+});

--- a/src/protocols/batch.ts
+++ b/src/protocols/batch.ts
@@ -1,0 +1,30 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+// 400 with a JSON-RPC error and no id, per the MCP Streamable HTTP spec.
+const sendBadRequest = (res: Response, message: string): void => {
+  res.status(400).json({ jsonrpc: '2.0', error: { code: -32600, message }, id: null });
+};
+
+/**
+ * Builds Express middleware that caps the number of messages in a JSON-RPC
+ * batch before the request reaches the MCP SDK.
+ *
+ * The SDK accepts batch arrays of any length, and every message in a batch can
+ * dispatch its own tool call, so one accepted HTTP request can fan out into an
+ * unbounded number of outbound Brave Search API calls. Capping the array length
+ * bounds that fan-out at the edge, independent of body size.
+ *
+ * Non-array bodies (the common single-message case) pass straight through.
+ */
+export const createBatchLimitGuard = (options: { maxBatchSize: number }): RequestHandler => {
+  const { maxBatchSize } = options;
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (Array.isArray(req.body) && req.body.length > maxBatchSize) {
+      sendBadRequest(res, `Batch size exceeds the limit of ${maxBatchSize} messages`);
+      return;
+    }
+
+    next();
+  };
+};

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -5,6 +5,8 @@ import createMcpServer from '../server.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ListToolsRequest, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { createDnsRebindingGuard } from './rebinding.js';
+import { createBatchLimitGuard } from './batch.js';
+import { HTTP_LIMITS } from '../constants.js';
 
 const yieldGenericServerError = (res: Response) => {
   res.status(500).json({
@@ -71,7 +73,9 @@ const createApp = () => {
     })
   );
 
-  app.use('/mcp', express.json());
+  app.use('/mcp', express.json({ limit: HTTP_LIMITS.maxBodySize }));
+
+  app.use('/mcp', createBatchLimitGuard({ maxBatchSize: HTTP_LIMITS.maxBatchSize }));
 
   app.all('/mcp', async (req: Request, res: Response) => {
     try {

--- a/src/tools/images/index.ts
+++ b/src/tools/images/index.ts
@@ -5,6 +5,7 @@ import type { ImageResult } from './types.js';
 import OutputSchema, { SimplifiedImageResultSchema } from './schemas/output.js';
 import { z } from 'zod';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describePlanRequirement } from '../../plans.js';
 
 export const name = 'brave_image_search';
 
@@ -13,9 +14,13 @@ export const annotations: ToolAnnotations = {
   openWorldHint: true,
 };
 
-export const description = `
+export const description =
+  `
     Performs an image search using the Brave Search API. Helpful for when you need pictures of people, places, things, graphic design ideas, art inspiration, and more. When relaying results in a markdown environment, it may be helpful to include images in the results (e.g., ![image.title](image.properties.url)).
-`;
+`.trim() +
+  `
+
+${describePlanRequirement('images')}`;
 
 export const execute = async (params: QueryParams) => {
   const response = await API.issueRequest<'images'>('images', params);

--- a/src/tools/llm_context/index.ts
+++ b/src/tools/llm_context/index.ts
@@ -9,6 +9,7 @@ import {
   type LlmContextInput as QueryParams,
 } from './schemas/input.js';
 import { LlmContextSearchApiResponseSchema } from './schemas/output.js';
+import { describePlanRequirement } from '../../plans.js';
 
 export const name = 'brave_llm_context';
 
@@ -17,7 +18,8 @@ export const annotations: ToolAnnotations = {
   openWorldHint: true,
 };
 
-export const description = `
+export const description =
+  `
     Retrieves pre-extracted, relevance-ranked web content using Brave's LLM Context API, optimized for AI agents, LLM grounding, and RAG pipelines. Unlike a traditional web search that returns links and short descriptions, this tool returns the actual substance of matching pages — text chunks, tables, code blocks, and structured data — so the model can reason over it directly.
 
     When to use:
@@ -28,7 +30,7 @@ export const description = `
         - When you need the contents of pages, not just titles, descriptions, and URLs
 
     When relaying results in markdown-supporting environments, cite the source URLs from the "sources" map.
-`.trim();
+`.trim() + `\n\n${describePlanRequirement('llmContext')}`;
 
 export const execute = async (params: QueryParams) => {
   const parsedParams = RequestParamsSchema.parse(params);

--- a/src/tools/local/index.ts
+++ b/src/tools/local/index.ts
@@ -11,6 +11,7 @@ import { formatWebResults } from '../web/index.js';
 import { stringify } from '../../utils.js';
 import { type WebSearchApiResponse } from '../web/types.js';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describePlanRequirement } from '../../plans.js';
 
 export const name = 'brave_local_search';
 
@@ -19,7 +20,8 @@ export const annotations: ToolAnnotations = {
   openWorldHint: true,
 };
 
-export const description = `
+export const description =
+  `
     Brave Local Search API provides enrichments for location search results. Access to this API is available only through the Brave Search API Pro plans; confirm the user's plan before using this tool (if the user does not have a Pro plan, use the brave_web_search tool). Searches for local businesses and places using Brave's Local Search API. Best for queries related to physical locations, businesses, restaurants, services, etc.
     
     Returns detailed information including:
@@ -28,7 +30,7 @@ export const description = `
         - Phone numbers and opening hours
 
     Use this when the query implies 'near me', 'in my area', or mentions specific locations (e.g., 'in San Francisco'). This tool automatically falls back to brave_web_search if no local results are found.
-`.trim();
+`.trim() + `\n\n${describePlanRequirement('localPois')}`;
 
 // Access to Local API is available through the Pro plans.
 export const execute = async (params: WebQueryParams) => {

--- a/src/tools/news/index.ts
+++ b/src/tools/news/index.ts
@@ -3,6 +3,7 @@ import params, { type QueryParams } from './params.js';
 import API from '../../BraveAPI/index.js';
 import { stringify } from '../../utils.js';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describePlanRequirement } from '../../plans.js';
 
 export const name = 'brave_news_search';
 
@@ -11,7 +12,8 @@ export const annotations: ToolAnnotations = {
   openWorldHint: true,
 };
 
-export const description = `
+export const description =
+  `
     This tool searches for news articles using Brave's News Search API based on the user's query. Use it when you need current news information, breaking news updates, or articles about specific topics, events, or entities.
     
     When to use:
@@ -28,7 +30,7 @@ export const description = `
         - "According to [Reuters](https://www.reuters.com/technology/china-bans/), China bans uncertified and recalled power banks on planes".
         - "The [New York Times](https://www.nytimes.com/2025/06/27/us/technology/ev-sales.html) reports that Tesla's EV sales have increased by 20%".
         - "According to [BBC News](https://www.bbc.com/news/world-europe-65910000), the UK government has announced a new policy to support renewable energy".
-`.trim();
+`.trim() + `\n\n${describePlanRequirement('news')}`;
 
 export const execute = async (params: QueryParams) => {
   const response = await API.issueRequest<'news'>('news', params);

--- a/src/tools/place_search/index.ts
+++ b/src/tools/place_search/index.ts
@@ -8,6 +8,7 @@ import {
   type PlaceSearchInput as QueryParams,
 } from './schemas/input.js';
 import { PlaceSearchApiResponseSchema } from './schemas/output.js';
+import { describePlanRequirement } from '../../plans.js';
 
 export const name = 'brave_place_search';
 
@@ -16,7 +17,8 @@ export const annotations: ToolAnnotations = {
   openWorldHint: true,
 };
 
-export const description = `
+export const description =
+  `
     Searches Brave's Place Search API. A single call may populate any combination of 'results' (POIs), 'cities', 'addresses', 'streets', and 'location' (the resolved search area), depending on the query's shape.
 
     When to use:
@@ -31,7 +33,7 @@ export const description = `
         - 'addresses' / 'streets' only surface when the query is address-/street-shaped AND geographically anchored.
         - 'location' format: US -- '<city> <state> <country>' (e.g. 'san francisco ca united states'); non-US -- '<city> <country>' (e.g. 'tokyo japan'). Capitalization and commas don't matter.
         - 'count' caps results (max 50, default 20). 'radius' (meters) biases toward closer results; it does NOT hard-limit the search area.
-`.trim();
+`.trim() + `\n\n${describePlanRequirement('placeSearch')}`;
 
 export const execute = async (params: QueryParams) => {
   const parsedParams = RequestParamsSchema.parse(params);

--- a/src/tools/summarizer/index.test.ts
+++ b/src/tools/summarizer/index.test.ts
@@ -2,21 +2,31 @@ import assert from 'node:assert/strict';
 import { afterEach, describe, it, mock } from 'node:test';
 import API, { BraveApiError } from '../../BraveAPI/index.js';
 import { SUMMARIZER_POLL } from '../../constants.js';
+import { describeAccessFailure } from '../../plans.js';
 import { execute, isRetryableError } from './index.js';
 
 const params = { key: 'test-key' } as Parameters<typeof execute>[0];
 
 describe('summarizer retry classification', () => {
   it('treats throttling and upstream failures as retryable', () => {
-    assert.equal(isRetryableError(new BraveApiError(429, 'Too Many Requests')), true);
-    assert.equal(isRetryableError(new BraveApiError(500, 'Internal Server Error')), true);
-    assert.equal(isRetryableError(new BraveApiError(503, 'Service Unavailable')), true);
+    assert.equal(isRetryableError(new BraveApiError(429, 'summarizer', 'Too Many Requests')), true);
+    assert.equal(
+      isRetryableError(new BraveApiError(500, 'summarizer', 'Internal Server Error')),
+      true
+    );
+    assert.equal(
+      isRetryableError(new BraveApiError(503, 'summarizer', 'Service Unavailable')),
+      true
+    );
   });
 
   it('treats deterministic client errors as permanent', () => {
-    assert.equal(isRetryableError(new BraveApiError(401, 'Unauthorized')), false);
-    assert.equal(isRetryableError(new BraveApiError(403, 'Forbidden')), false);
-    assert.equal(isRetryableError(new BraveApiError(422, 'Unprocessable Entity')), false);
+    assert.equal(isRetryableError(new BraveApiError(401, 'summarizer', 'Unauthorized')), false);
+    assert.equal(isRetryableError(new BraveApiError(403, 'summarizer', 'Forbidden')), false);
+    assert.equal(
+      isRetryableError(new BraveApiError(422, 'summarizer', 'Unprocessable Entity')),
+      false
+    );
   });
 
   it('treats errors without a status as transient', () => {
@@ -29,7 +39,7 @@ describe('summarizer polling', () => {
 
   it('issues one request -- not twenty -- when the API key is invalid', async () => {
     const issueRequest = mock.method(API, 'issueRequest', async () => {
-      throw new BraveApiError(401, 'Unauthorized');
+      throw new BraveApiError(401, 'summarizer', 'Unauthorized');
     });
 
     const result = await execute(params);
@@ -40,7 +50,7 @@ describe('summarizer polling', () => {
 
   it('still exhausts its attempts on retryable failures', async () => {
     const issueRequest = mock.method(API, 'issueRequest', async () => {
-      throw new BraveApiError(503, 'Service Unavailable');
+      throw new BraveApiError(503, 'summarizer', 'Service Unavailable');
     });
 
     const result = await execute(params);
@@ -89,5 +99,27 @@ describe('summarizer polling', () => {
 
     assert.ok(issueRequest.mock.callCount() < SUMMARIZER_POLL.pollAttempts);
     assert.equal(result.isError, true);
+  });
+});
+
+describe('summarizer error reporting', () => {
+  afterEach(() => mock.restoreAll());
+
+  it('tells the caller which plan the summarizer needs', async () => {
+    mock.method(API, 'issueRequest', async () => {
+      throw new BraveApiError(
+        403,
+        'summarizer',
+        'HTTP 403\n\n' + describeAccessFailure('summarizer')
+      );
+    });
+
+    const result = await execute(params);
+    const [block] = result.content;
+    const text = block.type === 'text' ? block.text : '';
+
+    assert.equal(result.isError, true);
+    assert.match(text, /Answers/);
+    assert.match(text, /retrying will not help/);
   });
 });

--- a/src/tools/summarizer/index.test.ts
+++ b/src/tools/summarizer/index.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+import API, { BraveApiError } from '../../BraveAPI/index.js';
+import { SUMMARIZER_POLL } from '../../constants.js';
+import { execute, isRetryableError } from './index.js';
+
+const params = { key: 'test-key' } as Parameters<typeof execute>[0];
+
+describe('summarizer retry classification', () => {
+  it('treats throttling and upstream failures as retryable', () => {
+    assert.equal(isRetryableError(new BraveApiError(429, 'Too Many Requests')), true);
+    assert.equal(isRetryableError(new BraveApiError(500, 'Internal Server Error')), true);
+    assert.equal(isRetryableError(new BraveApiError(503, 'Service Unavailable')), true);
+  });
+
+  it('treats deterministic client errors as permanent', () => {
+    assert.equal(isRetryableError(new BraveApiError(401, 'Unauthorized')), false);
+    assert.equal(isRetryableError(new BraveApiError(403, 'Forbidden')), false);
+    assert.equal(isRetryableError(new BraveApiError(422, 'Unprocessable Entity')), false);
+  });
+
+  it('treats errors without a status as transient', () => {
+    assert.equal(isRetryableError(new Error('socket hang up')), true);
+  });
+});
+
+describe('summarizer polling', () => {
+  afterEach(() => mock.restoreAll());
+
+  it('issues one request -- not twenty -- when the API key is invalid', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => {
+      throw new BraveApiError(401, 'Unauthorized');
+    });
+
+    const result = await execute(params);
+
+    assert.equal(issueRequest.mock.callCount(), 1);
+    assert.equal(result.isError, true);
+  });
+
+  it('still exhausts its attempts on retryable failures', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => {
+      throw new BraveApiError(503, 'Service Unavailable');
+    });
+
+    const result = await execute(params);
+
+    assert.equal(issueRequest.mock.callCount(), SUMMARIZER_POLL.pollAttempts);
+    assert.equal(result.isError, true);
+  });
+
+  it('paces polls when the summary is not yet complete', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => ({ status: 'pending' }));
+
+    const start = Date.now();
+    await execute(params);
+    const elapsed = Date.now() - start;
+
+    // Nineteen inter-attempt delays. The previous implementation slept only on
+    // the error path, so this case ran all twenty polls back to back.
+    const expected = (SUMMARIZER_POLL.pollAttempts - 1) * SUMMARIZER_POLL.pollIntervalMs;
+
+    assert.equal(issueRequest.mock.callCount(), SUMMARIZER_POLL.pollAttempts);
+    assert.ok(elapsed >= expected * 0.8, `expected pacing of ~${expected}ms, saw ${elapsed}ms`);
+  });
+
+  it('returns the summary as soon as one completes', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => ({
+      status: 'complete',
+      summary: [{ type: 'token', data: 'hello world' }],
+    }));
+
+    const result = await execute(params);
+
+    assert.equal(issueRequest.mock.callCount(), 1);
+    assert.equal(result.isError, false);
+
+    const [block] = result.content;
+    assert.equal(block.type, 'text');
+    assert.equal(block.type === 'text' ? block.text : undefined, 'hello world');
+  });
+
+  it('stops polling when the caller cancels', async () => {
+    const issueRequest = mock.method(API, 'issueRequest', async () => ({ status: 'pending' }));
+    const controller = new AbortController();
+
+    setTimeout(() => controller.abort(), SUMMARIZER_POLL.pollIntervalMs * 3);
+    const result = await execute(params, { signal: controller.signal });
+
+    assert.ok(issueRequest.mock.callCount() < SUMMARIZER_POLL.pollAttempts);
+    assert.equal(result.isError, true);
+  });
+});

--- a/src/tools/summarizer/index.ts
+++ b/src/tools/summarizer/index.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { summarizerQueryParams, type SummarizerQueryParams } from './params.js';
-import API from '../../BraveAPI/index.js';
+import API, { BraveApiError } from '../../BraveAPI/index.js';
+import { SUMMARIZER_POLL } from '../../constants.js';
 import { type SummarizerSearchApiResponse } from './types.js';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -26,11 +27,11 @@ export const description = `
     Requirements: Must first perform a web search using brave_web_search with summary=true parameter. Requires a Pro AI subscription to access the summarizer functionality.
 `.trim();
 
-export const execute = async (params: SummarizerQueryParams) => {
+export const execute = async (params: SummarizerQueryParams, extra?: { signal?: AbortSignal }) => {
   const response: CallToolResult = { content: [], isError: false };
 
   try {
-    const { summary } = await pollForSummary(params);
+    const { summary } = await pollForSummary(params, undefined, undefined, extra?.signal);
 
     if (!summary || summary.length === 0) {
       response.isError = true;
@@ -80,31 +81,74 @@ export const register = (mcpServer: McpServer) => {
   );
 };
 
+/**
+ * A summary that is still being generated is worth waiting for; a request the
+ * API has already rejected is not. Retry only on throttling (429) and upstream
+ * failures (5xx). Every other status -- an invalid or unsubscribed key (401,
+ * 403), a malformed request (422) -- is deterministic and will return the same
+ * result on every attempt, so retrying it only multiplies outbound requests.
+ *
+ * Errors that are not BraveApiError (network faults, JSON parse failures) have
+ * no status to judge and are treated as transient.
+ */
+export const isRetryableError = (error: unknown): boolean => {
+  if (!(error instanceof BraveApiError)) return true;
+  return error.status === 429 || error.status >= 500;
+};
+
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('Aborted'));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error('Aborted'));
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+
 const pollForSummary = async (
   params: SummarizerQueryParams,
-  pollInterval: number = 50,
-  attempts: number = 20
+  pollInterval: number = SUMMARIZER_POLL.pollIntervalMs,
+  attempts: number = SUMMARIZER_POLL.pollAttempts,
+  signal?: AbortSignal
 ): Promise<SummarizerSearchApiResponse> => {
-  let result: SummarizerSearchApiResponse | null = null;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    // Wait between attempts, not before the first one. The previous
+    // implementation only slept on the error path, so a well-formed response
+    // that was not yet 'complete' re-polled immediately -- issuing all
+    // remaining attempts back to back with no delay at all.
+    if (attempt > 0) {
+      await sleep(pollInterval, signal);
+    }
 
-  while (!result && attempts > 0) {
+    if (signal?.aborted) {
+      throw signal.reason ?? new Error('Aborted');
+    }
+
     try {
       const response = await API.issueRequest<'summarizer'>('summarizer', params);
       if (response.status === 'complete') {
-        result = response;
+        return response;
       }
     } catch (error) {
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      // Stop immediately on a failure that repeating cannot resolve.
+      if (!isRetryableError(error)) {
+        throw error;
+      }
     }
-
-    attempts--;
   }
 
-  if (!result) {
-    throw new Error('Summarizer summary could not be retrieved after multiple attempts.');
-  }
-
-  return result;
+  throw new Error('Summarizer summary could not be retrieved after multiple attempts.');
 };
 
 export default {

--- a/src/tools/summarizer/index.ts
+++ b/src/tools/summarizer/index.ts
@@ -4,6 +4,7 @@ import API, { BraveApiError } from '../../BraveAPI/index.js';
 import { SUMMARIZER_POLL } from '../../constants.js';
 import { type SummarizerSearchApiResponse } from './types.js';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describePlanRequirement } from '../../plans.js';
 
 export const name = 'brave_summarizer';
 
@@ -12,7 +13,8 @@ export const annotations: ToolAnnotations = {
   openWorldHint: true,
 };
 
-export const description = `
+export const description =
+  `
     Retrieves AI-generated summaries of web search results using Brave's Summarizer API. This tool processes search results to create concise, coherent summaries of information gathered from multiple sources.
 
     When to use:
@@ -25,7 +27,7 @@ export const description = `
     Returns a text summary that consolidates information from the search results. Optional features include inline references to source URLs and additional entity information.
 
     Requirements: Must first perform a web search using brave_web_search with summary=true parameter. Requires a Pro AI subscription to access the summarizer functionality.
-`.trim();
+`.trim() + `\n\n${describePlanRequirement('summarizer')}`;
 
 export const execute = async (params: SummarizerQueryParams, extra?: { signal?: AbortSignal }) => {
   const response: CallToolResult = { content: [], isError: false };
@@ -61,7 +63,13 @@ export const execute = async (params: SummarizerQueryParams, extra?: { signal?: 
     response.isError = true;
     response.content.push({
       type: 'text' as const,
-      text: 'Unable to retrieve a Summarizer summary.',
+      // Surface why it failed. A plan mismatch is the most common cause here --
+      // brave_summarizer needs a different plan than the search tools -- and a
+      // bare 'unable to retrieve' gives the caller nothing to act on.
+      text:
+        error instanceof BraveApiError
+          ? `Unable to retrieve a Summarizer summary.\n\n${error.message}`
+          : 'Unable to retrieve a Summarizer summary.',
     });
   }
 

--- a/src/tools/videos/index.ts
+++ b/src/tools/videos/index.ts
@@ -3,6 +3,7 @@ import params, { type QueryParams } from './params.js';
 import API from '../../BraveAPI/index.js';
 import { stringify } from '../../utils.js';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describePlanRequirement } from '../../plans.js';
 
 export const name = 'brave_video_search';
 
@@ -11,7 +12,8 @@ export const annotations: ToolAnnotations = {
   openWorldHint: true,
 };
 
-export const description = `
+export const description =
+  `
     Searches for videos using Brave's Video Search API and returns structured video results with metadata.
 
     When to use:
@@ -19,7 +21,7 @@ export const description = `
         - Useful for discovering video content, getting video metadata, or finding videos from specific creators/publishers.
 
     Returns a JSON list of video-related results with title, url, description, duration, and thumbnail_url.
-`.trim();
+`.trim() + `\n\n${describePlanRequirement('videos')}`;
 
 export const execute = async (params: QueryParams) => {
   const response = await API.issueRequest<'videos'>('videos', params);

--- a/src/tools/web/index.ts
+++ b/src/tools/web/index.ts
@@ -15,6 +15,7 @@ import type {
 } from './types.js';
 import { stringify } from '../../utils.js';
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describePlanRequirement } from '../../plans.js';
 
 export const name = 'brave_web_search';
 
@@ -23,7 +24,8 @@ export const annotations: ToolAnnotations = {
   openWorldHint: true,
 };
 
-export const description = `
+export const description =
+  `
     Performs web searches using the Brave Search API and returns comprehensive search results with rich metadata.
 
     When to use:
@@ -36,7 +38,7 @@ export const description = `
     Returns a JSON list of web results with title, description, and URL.
     
     When the "results_filter" parameter is empty, JSON results may also contain FAQ, Discussions, News, and Video results.
-`.trim();
+`.trim() + `\n\n${describePlanRequirement('web')}`;
 
 export const execute = async (params: QueryParams) => {
   const response = { content: [] as TextContent[], isError: false };


### PR DESCRIPTION
# Declare each tool's plan requirement and explain plan mismatches in errors

**Stacked on the batch-amplification PR** — it reuses the `BraveApiError` type
added there. Happy to rebase this standalone if you'd rather take them in the
other order, or land them together.

## The problem

Brave sells access as plans, and a subscription token is scoped to the plan it
was issued under. A key that works for `/web/search` is not guaranteed to work
for `/summarizer/search`. But this server takes exactly one key and points it at
nine endpoints spanning at least two plans.

When that mismatch happens, the server today gives the caller nothing to work
with. `brave_summarizer` catches the failure and returns:

```
Unable to retrieve a Summarizer summary.
```

The real 403 — including Brave's own `SUBSCRIPTION_TOKEN_INVALID` body — is
discarded. It is the only tool in the server that swallows its error, and it is
also the tool most likely to hit a plan mismatch, because it needs a different
plan from the seven search tools that share its key.

This matters more than it used to. The consumer of that error is now a model.
A model can act on "this endpoint needs the Answers plan." It cannot act on
"unable to retrieve."

## Changes

**`src/plans.ts` (new) — one place that knows which endpoint needs which plan.**
An `ENDPOINT_PLANS` map plus helpers to render it as prose. Tool descriptions
and error messages both read from this map, so they can't drift apart.

**`src/BraveAPI/index.ts` — auth failures say which plan is required.**
On 401/403/422, `issueRequest` appends the plan requirement to the error before
throwing. This happens once at the API boundary, so all nine endpoints get it
without touching the seven tools that have no error handling of their own.
`BraveApiError` also now carries `endpoint` and `requiredPlan` for callers that
want to branch on it rather than read prose.

**Every tool description now states its plan.** Previously two of eight
mentioned a plan at all (`brave_local_search` and `brave_summarizer`), and the
two newest — `brave_llm_context` and `brave_place_search` — said nothing. Now
each description ends with a generated line:

```
brave_web_search      -> Requires the Brave Search 'Search' plan.
brave_summarizer      -> Requires the Brave Search 'Answers' plan. Referred to as
                         'Pro AI' elsewhere in the Brave docs.
brave_place_search    -> Requires the Brave Search 'Search (Pro tier)' plan.
```

An agent reading the tool list can now see the requirement before it spends a
request finding out.

**`brave_summarizer` stops discarding the failure.** It still returns its
friendly message, with the underlying reason appended when the cause was a
Brave API error.

### What an agent sees now

```
403 Forbidden
{"error":{"code":"SUBSCRIPTION_TOKEN_INVALID","detail":"..."}}

Requires the Brave Search 'Answers' plan. Referred to as 'Pro AI' elsewhere in
the Brave docs. If your API key is subscribed to a different plan, this request
will fail on every attempt; retrying will not help. Review or change your plan
at https://api-dashboard.search.brave.com/app/subscriptions/subscribe
```

## Two things I need you to check

**1. The plan assignments are my best read of your own docs, not authoritative.**
I took the plan names from the `SKILL.md` banners in `brave/brave-search-skills`
and the plan notes already in this repo. Please correct any of these:

| Endpoint | Assigned plan | Basis |
|---|---|---|
| `web`, `images`, `videos`, `news` | Search | skills repo banners |
| `llmContext` | Search | `skills/llm-context/SKILL.md` |
| `localPois`, `localDescriptions` | Search (Pro tier) | this repo's own `local` description |
| `placeSearch` | Search (Pro tier) | **inferred** from the shared `/local/` path — least confident |
| `summarizer` | Answers | `skills/answers/SKILL.md` |

They're one edit each in `ENDPOINT_PLANS`.

**2. The naming is inconsistent across Brave's own surfaces.** This repo calls
it a "Pro AI subscription"; `brave-search-skills` calls it the "Answers" plan.
I went with Answers and noted the alias, but you'll know which is current.

## Tests

`src/plans.test.ts` plus additions to the summarizer tests. Includes a guard
that fails if a new endpoint is added without a plan assignment, and one that
asserts every registered tool states a plan requirement.

73/73 pass; `tsc --noEmit` and `prettier --check` clean.

## Related

`brave-search-cli#27` and `brave-search-skills#27` are the same root cause in
the other two repos: one key slot, several plans. This PR doesn't fix the
single-key limitation — it makes the resulting failure legible. Multi-key
support would be the larger change, and it should probably be designed across
all three repos at once rather than here alone.