### PR TITLE
docs: add bunx fallback for npm override conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,26 @@ Add this to your `claude_desktop_config.json`:
 }
 ```
 
+#### Bun
+
+If `npx` exits with `EOVERRIDE` because the current project's npm overrides
+conflict with a dependency, run the server with Bun instead. The `--bun` flag
+keeps the server on Bun's runtime:
+
+```json
+{
+  "mcpServers": {
+    "brave-search": {
+      "command": "bunx",
+      "args": ["--bun", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+      "env": {
+        "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
 ### Usage with VS Code
 
 For quick installation, use the one-click installation buttons below:


### PR DESCRIPTION
Documents `bunx --bun` as a fallback when `npx` fails on conflicting npm overrides in the calling project. The documented command was verified against a conflicting override fixture.

Closes #300
