### PR TITLE
Add context-cost badge — one datapoint you may want: brave_place_search alone is 17,282 tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 An MCP server implementation that integrates the Brave Search API, providing comprehensive search capabilities including web search, local business search, place search, image search, video search, news search, LLM context, and AI-powered summarization. This project supports both STDIO and HTTP transports, with STDIO as the default mode.
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/brave/brave-search-mcp-server)
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fbrave-search.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
 
 ## Migration
 


### PR DESCRIPTION
One line: a shields.io badge showing what the server's tool schemas cost in context tokens — currently **25,456 tokens across 8 tools**, measured 2026-08-16 at default configuration. Neutral transparency for users budgeting context windows; the number links to a reproducible methodology and refreshes weekly.

The reason this might actually be useful to you: the distribution is extremely skewed. **`brave_place_search` alone is 17,282 tokens — 68% of the total** — while the flagship `brave_web_search` is a lean 1,396. Whatever is generating that one tool's inputSchema (it looks like a deeply-expanded response schema embedded in the input definition) is a single-file fix that would move the server from the heaviest decile of the 57 popular servers we measured to comfortably mid-pack. Full capture: [results/brave-search/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/brave-search/measurement.json) (median across measured servers: 2,636).

Methodology: raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines from the published measurement. If you'd rather not carry the badge, close freely — no hard feelings (the per-tool datapoint above is yours either way). To own the number in your own CI: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).