### PR TITLE
fix: advertise tool schemas as JSON Schema 2020-12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@types/express": "5.0.6",
         "@types/node": "24.10.13",
+        "ajv": "8.20.0",
         "prettier": "3.8.1",
         "semver": "7.7.3",
         "shx": "0.4.0",
@@ -656,9 +657,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@types/express": "5.0.6",
     "@types/node": "24.10.13",
+    "ajv": "8.20.0",
     "prettier": "3.8.1",
     "semver": "7.7.3",
     "shx": "0.4.0",

--- a/src/jsonSchemaDialect.ts
+++ b/src/jsonSchemaDialect.ts
@@ -1,0 +1,82 @@
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  ListToolsRequestSchema,
+  type ListToolsResult,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+import { z, type ZodRawShape } from 'zod';
+import tools from './tools/index.js';
+
+/**
+ * The dialect servers MUST emit by default, per SEP-1613 §5.
+ * https://modelcontextprotocol.io/seps/1613-establish-json-schema-2020-12-as-default-dialect-f
+ */
+export const JSON_SCHEMA_2020_12 = 'https://json-schema.org/draft/2020-12/schema';
+
+type ToolSchemaShapes = {
+  inputSchema?: ZodRawShape;
+  outputSchema?: ZodRawShape;
+};
+
+const schemaShapesByTool = new Map<string, ToolSchemaShapes>(
+  Object.values(tools).map((tool) => [tool.name, tool as ToolSchemaShapes])
+);
+
+const toJsonSchema2020 = (shape: ZodRawShape, io: 'input' | 'output'): Tool['inputSchema'] =>
+  z.toJSONSchema(z.object(shape), {
+    target: 'draft-2020-12',
+    io,
+  }) as unknown as Tool['inputSchema'];
+
+type ListToolsHandler = (request: unknown, extra: unknown) => Promise<ListToolsResult>;
+
+// An absent `$schema` defaults to 2020-12, but says nothing about which dialect's
+// keywords were emitted, so only an explicit declaration counts as correct.
+const needsRetargeting = (schema?: Tool['inputSchema'] | Tool['outputSchema']): boolean =>
+  (schema as { $schema?: string } | undefined)?.$schema !== JSON_SCHEMA_2020_12;
+
+/**
+ * Re-emits advertised tool schemas as 2020-12, skipping any the SDK already got
+ * right - so this decays to a string comparison once the SDK is fixed, and can
+ * then be deleted.
+ *
+ * The SDK hardcodes draft-07 (`mcp.js` calls `toJsonSchemaCompat()` with no
+ * `target`), which 2020-12-only clients reject outright, and whose array-form
+ * `items` is invalid 2020-12 (`brave_place_search`'s coordinates tuple).
+ * Wrapping its handler preserves the other fields it emits.
+ *
+ * https://github.com/modelcontextprotocol/typescript-sdk/issues/2084 (PR #2085)
+ *
+ * Must be called after all tools are registered.
+ */
+export default function enforce2020Dialect(mcpServer: McpServer): void {
+  const requestHandlers = (
+    mcpServer.server as unknown as { _requestHandlers?: Map<string, ListToolsHandler> }
+  )._requestHandlers;
+
+  const listTools = requestHandlers?.get('tools/list');
+
+  // Only reachable through SDK internals; if a future version moves it, leave its
+  // output alone rather than failing to start - server.test.ts catches regressions.
+  if (!listTools) return;
+
+  mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request, extra) => {
+    const result = await listTools(request, extra);
+
+    for (const tool of result.tools) {
+      const shapes = schemaShapesByTool.get(tool.name);
+
+      if (!shapes) continue;
+
+      if (shapes.inputSchema && needsRetargeting(tool.inputSchema)) {
+        tool.inputSchema = toJsonSchema2020(shapes.inputSchema, 'input');
+      }
+
+      if (shapes.outputSchema && tool.outputSchema && needsRetargeting(tool.outputSchema)) {
+        tool.outputSchema = toJsonSchema2020(shapes.outputSchema, 'output');
+      }
+    }
+
+    return result;
+  });
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { Ajv2020 } from 'ajv/dist/2020.js';
 import { connectTestClient } from './testUtils/mcpTestHarness.js';
 import tools from './tools/index.js';
 
@@ -24,6 +25,31 @@ describe('MCP server <-> SDK Client wiring (in-memory)', () => {
 
     for (const tool of listedTools) {
       assert.ok(tool.inputSchema, `${tool.name} is missing an inputSchema`);
+    }
+  });
+
+  it('advertises valid JSON Schema 2020-12 schemas', async () => {
+    const { tools: listedTools } = await client.listTools();
+
+    // Compiling resolves the declared dialect, so a draft-07 tag fails here as
+    // readily as invalid 2020-12 keywords. The SDK does the Zod conversion, so
+    // only the wire format is worth asserting.
+    const ajv = new Ajv2020({ strict: false, validateFormats: false });
+
+    for (const tool of listedTools) {
+      assert.doesNotThrow(
+        () => ajv.compile(tool.inputSchema),
+        `${tool.name} has an invalid inputSchema`
+      );
+
+      const { outputSchema } = tool;
+
+      if (outputSchema) {
+        assert.doesNotThrow(
+          () => ajv.compile(outputSchema),
+          `${tool.name} has an invalid outputSchema`
+        );
+      }
     }
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import tools from './tools/index.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import pkg from '../package.json' with { type: 'json' };
 import { isToolPermittedByUser } from './config.js';
+import enforce2020Dialect from './jsonSchemaDialect.js';
 
 export default function createMcpServer(): McpServer {
   const mcpServer = new McpServer(
@@ -24,6 +25,9 @@ export default function createMcpServer(): McpServer {
     if (!isToolPermittedByUser(tool.name)) continue;
     tool.register(mcpServer);
   }
+
+  // Advertise 2020-12 schemas; the SDK would otherwise emit draft-07
+  enforce2020Dialect(mcpServer);
 
   return mcpServer;
 }

--- a/src/tools/images/index.ts
+++ b/src/tools/images/index.ts
@@ -45,8 +45,8 @@ export const register = (mcpServer: McpServer) => {
     {
       title: name,
       description: description,
-      inputSchema: params.shape,
-      outputSchema: OutputSchema.shape,
+      inputSchema: params,
+      outputSchema: OutputSchema,
       annotations: annotations,
     },
     execute

--- a/src/tools/llm_context/index.ts
+++ b/src/tools/llm_context/index.ts
@@ -51,8 +51,8 @@ export const register = (mcpServer: McpServer) => {
     {
       title: name,
       description: description,
-      inputSchema: LlmContextInputSchema.shape,
-      outputSchema: LlmContextSearchApiResponseSchema.shape,
+      inputSchema: LlmContextInputSchema,
+      outputSchema: LlmContextSearchApiResponseSchema,
       annotations: annotations,
     },
     execute

--- a/src/tools/local/index.ts
+++ b/src/tools/local/index.ts
@@ -79,7 +79,7 @@ export const register = (mcpServer: McpServer) => {
     {
       title: name,
       description: description,
-      inputSchema: webParams.shape,
+      inputSchema: webParams,
       annotations: annotations,
     },
     execute

--- a/src/tools/news/index.ts
+++ b/src/tools/news/index.ts
@@ -58,7 +58,7 @@ export const register = (mcpServer: McpServer) => {
     {
       title: name,
       description: description,
-      inputSchema: params.shape,
+      inputSchema: params,
       annotations: annotations,
     },
     execute

--- a/src/tools/place_search/index.ts
+++ b/src/tools/place_search/index.ts
@@ -56,8 +56,8 @@ export const register = (mcpServer: McpServer) => {
     {
       title: name,
       description: description,
-      inputSchema: PlaceSearchInputSchema.shape,
-      outputSchema: PlaceSearchApiResponseSchema.shape,
+      inputSchema: PlaceSearchInputSchema,
+      outputSchema: PlaceSearchApiResponseSchema,
       annotations: annotations,
     },
     execute

--- a/src/tools/summarizer/index.ts
+++ b/src/tools/summarizer/index.ts
@@ -73,7 +73,7 @@ export const register = (mcpServer: McpServer) => {
     {
       title: name,
       description: description,
-      inputSchema: summarizerQueryParams.shape,
+      inputSchema: summarizerQueryParams,
       annotations: annotations,
     },
     execute

--- a/src/tools/videos/index.ts
+++ b/src/tools/videos/index.ts
@@ -43,7 +43,7 @@ export const register = (mcpServer: McpServer) => {
     {
       title: name,
       description: description,
-      inputSchema: params.shape,
+      inputSchema: params,
       annotations: annotations,
     },
     execute

--- a/src/tools/web/index.ts
+++ b/src/tools/web/index.ts
@@ -126,7 +126,7 @@ export const register = (mcpServer: McpServer) => {
     {
       title: name,
       description: description,
-      inputSchema: params.shape,
+      inputSchema: params,
       annotations: annotations,
     },
     execute


### PR DESCRIPTION
Every schema we advertise on `tools/list` declared draft-07, so MCP clients that validate against 2020-12 rejected our tool definitions outright — taking down the whole tool list, before any request reaches the Brave API. Most visible on the three tools that declare an `outputSchema` (`brave_image_search`, `brave_llm_context`, `brave_place_search`), since that is the schema clients compile.

The cause is upstream, not in our schemas: the SDK converts our Zod schemas on every `tools/list` with a hardcoded draft-07 target — `mcp.js` calls `toJsonSchemaCompat()` without a `target`, and `mapMiniTarget(undefined)` falls back to `'draft-7'`. No `registerTool` option overrides it, and 1.30.0 is the latest release. See modelcontextprotocol/typescript-sdk#2084 (fix pending in https://github.com/modelcontextprotocol/typescript-sdk/pull/2085); the SDK's v2 line already hardcodes `target: 'draft-2020-12'`.

SEP-1613 §5 requires servers to generate 2020-12 by default, so this re-emits the schemas on the `tools/list` response. Each correction is conditional per schema, so it decays to a string comparison — and can be deleted outright —once the SDK emits 2020-12 itself.

**No schema file changed.** Re-targeting also fixes `brave_place_search`'s coordinates tuple, which emitted draft-07's array-form `items` (invalid under 2020-12, where positional validation moved to `prefixItems`); Zod emits `prefixItems` from the target alone.

### Testing

Extends the `tools/list` integration test to compile every advertised input and output schema with a 2020-12 validator. This has to assert the wire format rather than our Zod definitions, because the SDK performs the conversion — and the SDK's own default client validator is Ajv draft-07 with schema validation disabled, so it accepts output that conformant clients reject. Verified red without the fix, green with it.

Fixes #235