### PR TITLE
fix: queue search calls so parallel tools don't 429

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The server supports the following environment variables:
 - `BRAVE_MCP_ENABLED_TOOLS`: When used, specifies a space-separated whitelist for supported tools
 - `BRAVE_MCP_DISABLED_TOOLS`: When used, specifies a space-separated blacklist for supported tools
 - `BRAVE_MCP_STATELESS`: HTTP stateless mode (default: "true").  When running on Amazon Bedrock Agentcore, set to "true".
+- `BRAVE_MCP_MIN_REQUEST_INTERVAL_MS`: Minimum gap between Brave Search API calls in milliseconds (default: `1000`, matching the free-tier 1 req/sec cap). Set to `0` to disable. Helps when an agent fires a few tools in parallel and would otherwise 429.
 
 ### Command Line Options
 
@@ -198,6 +199,7 @@ Options:
   --enabled-tools             Tools whitelist (only the specified tools will be enabled)
   --disabled-tools            Tools blacklist (included tools will be disabled)
   --stateless  <boolean>      HTTP Stateless flag
+  --min-request-interval-ms <number>  Min gap between Search API calls in ms (default: 1000, 0 disables)
 ```
 
 ## Installation

--- a/src/BraveAPI/index.test.ts
+++ b/src/BraveAPI/index.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import config from '../config.js';
+import { resetRateLimitState } from '../utils.js';
+import API from './index.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  config.ready = false;
+  config.minRequestIntervalMs = 1000;
+  resetRateLimitState();
+});
+
+function jsonResponse(body: unknown, init: { status?: number; retryAfter?: string } = {}) {
+  const headers = new Headers({ 'content-type': 'application/json' });
+  if (init.retryAfter) {
+    headers.set('retry-after', init.retryAfter);
+  }
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    statusText: init.status === 429 ? 'Too Many Requests' : 'OK',
+    headers,
+  });
+}
+
+describe('issueRequest rate limiting', () => {
+  it('spaces out parallel calls once the server is ready', async () => {
+    const startedAt: number[] = [];
+    config.ready = true;
+    config.minRequestIntervalMs = 40;
+    resetRateLimitState();
+
+    globalThis.fetch = (async () => {
+      startedAt.push(Date.now());
+      return jsonResponse({ type: 'search', web: { results: [] } });
+    }) as typeof fetch;
+
+    await Promise.all([
+      API.issueRequest('web', { q: 'one' } as never),
+      API.issueRequest('web', { q: 'two' } as never),
+      API.issueRequest('web', { q: 'three' } as never),
+    ]);
+
+    startedAt.sort((a, b) => a - b);
+    assert.equal(startedAt.length, 3);
+    assert.ok(startedAt[1] - startedAt[0] >= 30);
+    assert.ok(startedAt[2] - startedAt[1] >= 30);
+  });
+
+  it('retries a 429 using Retry-After', async () => {
+    let calls = 0;
+    config.ready = true;
+    config.minRequestIntervalMs = 0;
+    resetRateLimitState();
+
+    globalThis.fetch = (async () => {
+      calls += 1;
+      if (calls === 1) {
+        return jsonResponse({ error: 'slow down' }, { status: 429, retryAfter: '0' });
+      }
+      return jsonResponse({ type: 'search', web: { results: [] } });
+    }) as typeof fetch;
+
+    const result = await API.issueRequest('web', { q: 'retry' } as never);
+    assert.equal(calls, 2);
+    assert.equal((result as { type: string }).type, 'search');
+  });
+
+  it('does not throttle when config is not ready (tests / unused client)', async () => {
+    const startedAt: number[] = [];
+    config.ready = false;
+    config.minRequestIntervalMs = 1000;
+    resetRateLimitState();
+
+    globalThis.fetch = (async () => {
+      startedAt.push(Date.now());
+      return jsonResponse({ type: 'search', web: { results: [] } });
+    }) as typeof fetch;
+
+    await Promise.all([
+      API.issueRequest('web', { q: 'a' } as never),
+      API.issueRequest('web', { q: 'b' } as never),
+    ]);
+
+    startedAt.sort((a, b) => a - b);
+    assert.ok(startedAt[1] - startedAt[0] < 200);
+  });
+});

--- a/src/BraveAPI/index.ts
+++ b/src/BraveAPI/index.ts
@@ -1,6 +1,8 @@
 import type { Endpoints } from './types.js';
 import config from '../config.js';
-import { stringify } from '../utils.js';
+import { parseRetryAfterMs, stringify, waitForRateLimit } from '../utils.js';
+
+const MAX_429_RETRIES = 3;
 
 const typeToPathMap: Record<keyof Endpoints, string> = {
   images: '/res/v1/images/search',
@@ -46,9 +48,6 @@ async function issueRequest<T extends keyof Endpoints>(
   parameters: Endpoints[T]['params'],
   requestHeaders: Endpoints[T]['requestHeaders'] = {} as Endpoints[T]['requestHeaders']
 ): Promise<Endpoints[T]['response']> {
-  // TODO (Sampson): Improve rate-limit logic to support self-throttling and n-keys
-  // checkRateLimit();
-
   // Determine URL, and setup parameters
   const url = new URL(`https://api.search.brave.com${typeToPathMap[endpoint]}`);
   const queryParams = new URLSearchParams();
@@ -114,27 +113,41 @@ async function issueRequest<T extends keyof Endpoints>(
     headers.set(key, String(value));
   }
 
-  const response = await fetch(urlWithParams, { headers });
+  const intervalMs = config.ready ? config.minRequestIntervalMs : 0;
+  let lastError = 'Request failed';
 
-  // Handle Error
-  if (!response.ok) {
-    let errorMessage = `${response.status} ${response.statusText}`;
+  for (let attempt = 0; attempt <= MAX_429_RETRIES; attempt++) {
+    await waitForRateLimit(intervalMs);
 
-    try {
+    const response = await fetch(urlWithParams, { headers });
+
+    if (response.ok) {
       const responseBody = await response.json();
-      errorMessage += `\n${stringify(responseBody, true)}`;
-    } catch (error) {
-      errorMessage += `\n${await response.text()}`;
+      return responseBody as Endpoints[T]['response'];
     }
 
-    // TODO (Sampson): Setup proper error handling, updating state, etc.
-    throw new Error(errorMessage);
+    lastError = `${response.status} ${response.statusText}`;
+    try {
+      const responseBody = await response.json();
+      lastError += `\n${stringify(responseBody, true)}`;
+    } catch {
+      lastError += `\n${await response.text()}`;
+    }
+
+    if (response.status !== 429 || attempt === MAX_429_RETRIES) {
+      throw new Error(lastError);
+    }
+
+    const retryAfterMs = parseRetryAfterMs(
+      response.headers.get('retry-after'),
+      Math.max(intervalMs, 1000)
+    );
+    if (retryAfterMs > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, retryAfterMs));
+    }
   }
 
-  // Return Response
-  const responseBody = await response.json();
-
-  return responseBody as Endpoints[T]['response'];
+  throw new Error(lastError);
 }
 
 export default {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -17,6 +17,7 @@ const CONFIG_ENV_VARS = [
   'BRAVE_MCP_ALLOWED_ORIGINS',
   'BRAVE_MCP_ALLOWED_HOSTS',
   'BRAVE_MCP_STATELESS',
+  'BRAVE_MCP_MIN_REQUEST_INTERVAL_MS',
 ] as const;
 
 describe('getOptions', () => {
@@ -153,6 +154,28 @@ describe('getOptions', () => {
     assert.notEqual(options, false);
     if (options) {
       assert.deepEqual(options.allowedOrigins, ['https://a.example', 'https://b.example']);
+    }
+  });
+
+  it('defaults minRequestIntervalMs to 1000', () => {
+    process.argv = ['node', 'index.js', '--brave-api-key', 'key'];
+
+    const options = getOptions();
+
+    assert.notEqual(options, false);
+    if (options) {
+      assert.equal(options.minRequestIntervalMs, 1000);
+    }
+  });
+
+  it('parses --min-request-interval-ms', () => {
+    process.argv = ['node', 'index.js', '--brave-api-key', 'key', '--min-request-interval-ms', '0'];
+
+    const options = getOptions();
+
+    assert.notEqual(options, false);
+    if (options) {
+      assert.equal(options.minRequestIntervalMs, 0);
     }
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,13 @@ import { LoggingLevel, LoggingLevelSchema } from '@modelcontextprotocol/sdk/type
 import { Command } from 'commander';
 import dotenv from 'dotenv';
 import tools from './tools/index.js';
-import { parseDelimitedList, parsePort, readBraveApiKeyFromFile } from './utils.js';
+import {
+  DEFAULT_MIN_REQUEST_INTERVAL_MS,
+  parseDelimitedList,
+  parseIntervalMs,
+  parsePort,
+  readBraveApiKeyFromFile,
+} from './utils.js';
 
 dotenv.config({ debug: false, quiet: true });
 
@@ -27,6 +33,7 @@ type Configuration = {
   stateless: boolean;
   allowedOrigins: string[];
   allowedHosts: string[];
+  minRequestIntervalMs: number;
 };
 
 const state: Configuration & { ready: boolean } = {
@@ -41,6 +48,7 @@ const state: Configuration & { ready: boolean } = {
   stateless: false,
   allowedOrigins: [],
   allowedHosts: [],
+  minRequestIntervalMs: DEFAULT_MIN_REQUEST_INTERVAL_MS,
 };
 
 export function isToolPermittedByUser(toolName: string): boolean {
@@ -97,6 +105,11 @@ export function getOptions(): Configuration | false {
       '--stateless <boolean>',
       'whether the server should be stateless',
       process.env.BRAVE_MCP_STATELESS === 'true' ? true : false
+    )
+    .option(
+      '--min-request-interval-ms <number>',
+      'minimum gap between Brave Search API calls in ms (default: 1000, 0 disables)',
+      process.env.BRAVE_MCP_MIN_REQUEST_INTERVAL_MS ?? String(DEFAULT_MIN_REQUEST_INTERVAL_MS)
     )
     .allowUnknownOption()
     .parse(process.argv);
@@ -158,6 +171,14 @@ export function getOptions(): Configuration | false {
     return false;
   }
 
+  const minRequestIntervalMs = parseIntervalMs(options.minRequestIntervalMs);
+  if (minRequestIntervalMs === null) {
+    console.error(
+      `Invalid --min-request-interval-ms value: '${options.minRequestIntervalMs}'. Must be an integer between 0 and 60000.`
+    );
+    return false;
+  }
+
   if (options.transport === 'http') {
     const port = parsePort(options.port);
     if (port === null) {
@@ -183,6 +204,7 @@ export function getOptions(): Configuration | false {
 
   const allowedHosts = parseDelimitedList(options.allowedHosts);
   options.allowedHosts = allowedHosts;
+  options.minRequestIntervalMs = minRequestIntervalMs;
 
   // Update state
   state.braveApiKey = braveApiKey;
@@ -195,6 +217,7 @@ export function getOptions(): Configuration | false {
   state.stateless = options.stateless;
   state.allowedOrigins = allowedOrigins;
   state.allowedHosts = allowedHosts;
+  state.minRequestIntervalMs = minRequestIntervalMs;
   state.ready = true;
 
   return options as Configuration;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -3,7 +3,51 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import { isLoopbackHostname, parsePort, readBraveApiKeyFromFile } from './utils.js';
+import {
+  isLoopbackHostname,
+  parseIntervalMs,
+  parsePort,
+  parseRetryAfterMs,
+  readBraveApiKeyFromFile,
+  resetRateLimitState,
+  waitForRateLimit,
+} from './utils.js';
+
+describe('parseIntervalMs', () => {
+  it('accepts 0 and typical gaps', () => {
+    assert.equal(parseIntervalMs(0), 0);
+    assert.equal(parseIntervalMs('1000'), 1000);
+    assert.equal(parseIntervalMs(250), 250);
+  });
+
+  it('rejects junk and values over a minute', () => {
+    assert.equal(parseIntervalMs('nope'), null);
+    assert.equal(parseIntervalMs(-1), null);
+    assert.equal(parseIntervalMs(60001), null);
+    assert.equal(parseIntervalMs(undefined), null);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds', () => {
+    assert.equal(parseRetryAfterMs('2', 1000), 2000);
+    assert.equal(parseRetryAfterMs('0', 1000), 0);
+  });
+
+  it('falls back when the header is missing or garbage', () => {
+    assert.equal(parseRetryAfterMs(null, 750), 750);
+    assert.equal(parseRetryAfterMs('soon', 750), 750);
+  });
+});
+
+describe('waitForRateLimit', () => {
+  it('no-ops when interval is 0', async () => {
+    resetRateLimitState();
+    const start = Date.now();
+    await Promise.all([waitForRateLimit(0), waitForRateLimit(0)]);
+    assert.ok(Date.now() - start < 50);
+  });
+});
 
 describe('parsePort', () => {
   it('accepts valid integer ports', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,23 +1,57 @@
 import { readFileSync } from 'node:fs';
 import { RATE_LIMIT } from './constants.js';
 
-let requestCount = {
-  second: 0,
-  month: 0,
-  lastReset: Date.now(),
-};
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-export function checkRateLimit() {
-  const now = Date.now();
-  if (now - requestCount.lastReset > 1000) {
-    requestCount.second = 0;
-    requestCount.lastReset = now;
+let rateLimitQueue: Promise<void> = Promise.resolve();
+let lastRequestStartedAt = 0;
+
+/** Default gap between Brave Search API calls (free tier is 1 req/sec). */
+export const DEFAULT_MIN_REQUEST_INTERVAL_MS = Math.ceil(1000 / RATE_LIMIT.perSecond);
+
+export function resetRateLimitState() {
+  rateLimitQueue = Promise.resolve();
+  lastRequestStartedAt = 0;
+}
+
+/**
+ * Serializes outbound API calls so we don't blow past the Search API's
+ * per-second cap when an agent fires a few tools at once.
+ */
+export async function waitForRateLimit(intervalMs: number): Promise<void> {
+  if (intervalMs <= 0) {
+    return;
   }
-  if (requestCount.second >= RATE_LIMIT.perSecond || requestCount.month >= RATE_LIMIT.perMonth) {
-    throw new Error('Rate limit exceeded');
+
+  const run = async () => {
+    const waitMs = lastRequestStartedAt + intervalMs - Date.now();
+    if (waitMs > 0) {
+      await sleep(waitMs);
+    }
+    lastRequestStartedAt = Date.now();
+  };
+
+  const next = rateLimitQueue.then(run, run);
+  rateLimitQueue = next;
+  await next;
+}
+
+export function parseRetryAfterMs(header: string | null, fallbackMs: number): number {
+  if (!header) {
+    return fallbackMs;
   }
-  requestCount.second++;
-  requestCount.month++;
+
+  const trimmed = header.trim();
+  if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    return Math.max(0, Math.round(Number.parseFloat(trimmed) * 1000));
+  }
+
+  const dateMs = Date.parse(trimmed);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return fallbackMs;
 }
 
 export function stringify(data: any, pretty = false) {
@@ -96,6 +130,32 @@ export function parsePort(value: unknown): number | null {
 
   const parsed = Number.parseInt(text, 10);
   if (parsed < 1 || parsed > 65535) {
+    return null;
+  }
+
+  return parsed;
+}
+
+/** Non-negative integer milliseconds. `0` disables throttling. */
+export function parseIntervalMs(value: unknown): number | null {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value < 0 || value > 60_000) {
+      return null;
+    }
+    return value;
+  }
+
+  const text = String(value).trim();
+  if (!/^\d+$/.test(text)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(text, 10);
+  if (parsed < 0 || parsed > 60_000) {
     return null;
   }
 


### PR DESCRIPTION
hey @jonathansampson

agents love firing a few brave search tools at once, which instantly 429s on the free 1 rps cap. there's already a TODO on `checkRateLimit` in `BraveAPI` for this — the old helper just threw, which is even worse for the agent.

this one:
- puts outbound search calls through a queue (1s gap by default)
- retries 429s a couple times, honoring `Retry-After` when it's there
- `BRAVE_MCP_MIN_REQUEST_INTERVAL_MS` / `--min-request-interval-ms` if you want it tighter, or `0` to turn it off
- n-keys / multi-token stuff left for later

tests cover the queue + retry path. `npm test` and `npm run build` are green locally.

closes #238
related: #162