### PR TITLE
fix: optional bearer token for HTTP /mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,14 @@ The server supports the following environment variables:
 - `BRAVE_API_KEY_FILE`: Path to a file containing your Brave Search API key. When set, this takes precedence over `BRAVE_API_KEY`. Useful for Docker secrets and similar mounted-secret setups.
 - `BRAVE_MCP_TRANSPORT`: Transport mode ("http" or "stdio", default: "stdio")
 - `BRAVE_MCP_PORT`: HTTP server port (default: 8080)
-- `BRAVE_MCP_HOST`: HTTP server host (default: "127.0.0.1"). Binds to loopback only by default; set to "0.0.0.0" to expose the server on all interfaces (required inside containers and on Amazon Bedrock AgentCore). Only do this on a trusted network, since the HTTP endpoint is unauthenticated.
+- `BRAVE_MCP_HOST`: HTTP server host (default: "127.0.0.1"). Binds to loopback only by default; set to "0.0.0.0" to expose the server on all interfaces (required inside containers and on Amazon Bedrock AgentCore). Only do this on a trusted network. HTTP `/mcp` is unauthenticated unless you set `BRAVE_MCP_AUTH_TOKEN`.
 - `BRAVE_MCP_ALLOWED_ORIGINS`: Space- or comma-separated list of additional `Origin` header values permitted for the HTTP transport. Loopback origins are always allowed; browser requests carrying any other `Origin` are rejected with HTTP 403 to guard against DNS rebinding. Set this when a browser-based client on a real domain needs access.
 - `BRAVE_MCP_ALLOWED_HOSTS`: Space- or comma-separated list of hostnames permitted in the `Host` header of the HTTP transport. Matching is on the hostname only and is case-insensitive; a numeric port in an entry (e.g. `mcp.example.com:8080`) is accepted but ignored for matching. Optional, opt-in defense-in-depth: when unset (default) the `Host` header is not validated, so reverse-proxy and custom-domain deployments are unaffected. When set, only loopback hosts and the listed hostnames are accepted; any other `Host` (including malformed/non-numeric ports) is rejected with HTTP 403.
 - `BRAVE_MCP_LOG_LEVEL`: Desired logging level("debug", "info", "notice", "warning", "error", "critical", "alert", or "emergency", default: "info")
 - `BRAVE_MCP_ENABLED_TOOLS`: When used, specifies a space-separated whitelist for supported tools
 - `BRAVE_MCP_DISABLED_TOOLS`: When used, specifies a space-separated blacklist for supported tools
 - `BRAVE_MCP_STATELESS`: HTTP stateless mode (default: "true").  When running on Amazon Bedrock Agentcore, set to "true".
+- `BRAVE_MCP_AUTH_TOKEN`: Optional shared secret for HTTP `/mcp`. When set, clients must send `Authorization: Bearer <token>`. `/ping` stays open. Leave unset for local stdio/loopback as today.
 
 ### Command Line Options
 
@@ -198,6 +199,7 @@ Options:
   --enabled-tools             Tools whitelist (only the specified tools will be enabled)
   --disabled-tools            Tools blacklist (included tools will be disabled)
   --stateless  <boolean>      HTTP Stateless flag
+  --auth-token <string>       Optional bearer token for HTTP /mcp
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ Options:
   --logging-level <string>    Desired logging level (one of _debug_, _info_, _notice_, _warning_, _error_, _critical_, _alert_, or _emergency_)
   --enabled-tools             Tools whitelist (only the specified tools will be enabled)
   --disabled-tools            Tools blacklist (included tools will be disabled)
-  --stateless  <boolean>      HTTP Stateless flag
-  --auth-token <string>       Optional bearer token for HTTP /mcp
+  --stateless  <boolean>      HTTP Stateless flag (session handling only; does not affect auth)
+  --auth-token <string>       Optional bearer token for HTTP /mcp (e.g. Authorization: Bearer <token>)
 ```
 
 ## Installation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - BRAVE_MCP_LOG_LEVEL=info
       - BRAVE_MCP_ENABLED_TOOLS
       - BRAVE_MCP_DISABLED_TOOLS
+      - BRAVE_MCP_AUTH_TOKEN
     init: true
     ports:
       - 8080:8080

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -17,6 +17,7 @@ const CONFIG_ENV_VARS = [
   'BRAVE_MCP_ALLOWED_ORIGINS',
   'BRAVE_MCP_ALLOWED_HOSTS',
   'BRAVE_MCP_STATELESS',
+  'BRAVE_MCP_AUTH_TOKEN',
 ] as const;
 
 describe('getOptions', () => {
@@ -153,6 +154,17 @@ describe('getOptions', () => {
     assert.notEqual(options, false);
     if (options) {
       assert.deepEqual(options.allowedOrigins, ['https://a.example', 'https://b.example']);
+    }
+  });
+
+  it('parses --auth-token', () => {
+    process.argv = ['node', 'index.js', '--brave-api-key', 'key', '--auth-token', 'secret'];
+
+    const options = getOptions();
+
+    assert.notEqual(options, false);
+    if (options) {
+      assert.equal(options.httpAuthToken, 'secret');
     }
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ type Configuration = {
   stateless: boolean;
   allowedOrigins: string[];
   allowedHosts: string[];
+  httpAuthToken: string;
 };
 
 const state: Configuration & { ready: boolean } = {
@@ -41,6 +42,7 @@ const state: Configuration & { ready: boolean } = {
   stateless: false,
   allowedOrigins: [],
   allowedHosts: [],
+  httpAuthToken: '',
 };
 
 export function isToolPermittedByUser(toolName: string): boolean {
@@ -97,6 +99,11 @@ export function getOptions(): Configuration | false {
       '--stateless <boolean>',
       'whether the server should be stateless',
       process.env.BRAVE_MCP_STATELESS === 'true' ? true : false
+    )
+    .option(
+      '--auth-token <string>',
+      'optional bearer token for HTTP /mcp (Authorization: Bearer ...)',
+      process.env.BRAVE_MCP_AUTH_TOKEN ?? ''
     )
     .allowUnknownOption()
     .parse(process.argv);
@@ -184,6 +191,10 @@ export function getOptions(): Configuration | false {
   const allowedHosts = parseDelimitedList(options.allowedHosts);
   options.allowedHosts = allowedHosts;
 
+  const httpAuthToken = typeof options.authToken === 'string' ? options.authToken.trim() : '';
+  options.authToken = httpAuthToken;
+  (options as Configuration).httpAuthToken = httpAuthToken;
+
   // Update state
   state.braveApiKey = braveApiKey;
   state.transport = options.transport;
@@ -195,6 +206,7 @@ export function getOptions(): Configuration | false {
   state.stateless = options.stateless;
   state.allowedOrigins = allowedOrigins;
   state.allowedHosts = allowedHosts;
+  state.httpAuthToken = httpAuthToken;
   state.ready = true;
 
   return options as Configuration;

--- a/src/protocols/http.test.ts
+++ b/src/protocols/http.test.ts
@@ -214,3 +214,63 @@ describe('http Host validation (opt-in)', () => {
     assert.equal(res.status, 403);
   });
 });
+
+describe('http bearer auth (opt-in)', () => {
+  let server: Server;
+  let baseUrl: string;
+  const originalToken = config.httpAuthToken;
+
+  const post = (authorization?: string) =>
+    fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...(authorization ? { authorization } : {}),
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+    });
+
+  before(async () => {
+    config.httpAuthToken = 'test-token';
+    const app = httpServer.createApp();
+    server = app.listen(0);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const port = (server.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    config.httpAuthToken = originalToken;
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    );
+  });
+
+  it('rejects /mcp without a bearer token', async () => {
+    const res = await post();
+    const body = await res.json();
+
+    assert.equal(res.status, 401);
+    assert.deepEqual(body, {
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Unauthorized' },
+      id: null,
+    });
+  });
+
+  it('rejects a bad bearer token', async () => {
+    const res = await post('Bearer nope');
+    assert.equal(res.status, 401);
+  });
+
+  it('allows /mcp with the configured bearer token', async () => {
+    const res = await post('Bearer test-token');
+    assert.notEqual(res.status, 401);
+  });
+
+  it('leaves /ping open', async () => {
+    const res = await fetch(`${baseUrl}/ping`);
+    assert.equal(res.status, 200);
+  });
+});

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -1,10 +1,43 @@
-import { randomUUID } from 'node:crypto';
-import express, { type Request, type Response } from 'express';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
+import express, { type NextFunction, type Request, type Response } from 'express';
 import config from '../config.js';
 import createMcpServer from '../server.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ListToolsRequest, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { createDnsRebindingGuard } from './rebinding.js';
+
+const isBearerAuthorized = (header: string | undefined, token: string): boolean => {
+  if (!header?.startsWith('Bearer ')) {
+    return false;
+  }
+
+  const provided = Buffer.from(header.slice('Bearer '.length));
+  const expected = Buffer.from(token);
+  if (provided.length !== expected.length) {
+    return false;
+  }
+
+  return timingSafeEqual(provided, expected);
+};
+
+const requireHttpAuth = (req: Request, res: Response, next: NextFunction) => {
+  const token = config.httpAuthToken;
+  if (!token) {
+    next();
+    return;
+  }
+
+  if (isBearerAuthorized(req.headers.authorization, token)) {
+    next();
+    return;
+  }
+
+  res.status(401).json({
+    jsonrpc: '2.0',
+    error: { code: -32001, message: 'Unauthorized' },
+    id: null,
+  });
+};
 
 const yieldGenericServerError = (res: Response) => {
   res.status(500).json({
@@ -72,6 +105,7 @@ const createApp = () => {
   );
 
   app.use('/mcp', express.json());
+  app.use('/mcp', requireHttpAuth);
 
   app.all('/mcp', async (req: Request, res: Response) => {
     try {


### PR DESCRIPTION
@jonathansampson this is for #327

http /mcp is wide open right now, which is fine on loopback but sketchy if you bind 0.0.0.0. i didn't want to break existing setups so this is opt-in:

- set `BRAVE_MCP_AUTH_TOKEN` or `--auth-token`
- clients send `Authorization: Bearer <token>`
- `/ping` stays unauthenticated so healthchecks still work
- no token configured = same behavior as today

not a full auth story (no per-user stuff), just a shared secret so random clients can't burn your search quota.

closes #327