### PR TITLE
docs: add fx to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,44 @@ For manual installation, add the following to your User Settings (JSON) or `.vsc
 }
 ```
 
+### Usage with fx
+
+Add this to your `~/.fx/mcp.json`, creating the file if it does not exist:
+
+#### Docker
+
+```json
+{
+  "mcp": {
+    "brave-search": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "BRAVE_API_KEY", "docker.io/mcp/brave-search"],
+      "env": {
+        "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+#### NPX
+
+```json
+{
+  "mcp": {
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+      "env": {
+        "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+Start fx, or type `/mcp reload` if it is already running. To verify the connection, type `/mcp list`.
+
 ## Build
 
 ### Docker


### PR DESCRIPTION
Adds fx to the installation instructions, after Claude Desktop and VS Code.

[fx](https://github.com/vercel-labs/fx) is an open source coding agent from Vercel Labs, written in Zig. It reads MCP server definitions from the `mcp` key in `~/.fx/mcp.json`, so the JSON shape differs slightly from the two sections above it.

Verified against the live API with `@brave/brave-search-mcp-server@2.1.3` over stdio: the server negotiates protocol `2025-11-25`, exposes all 8 tools, and `brave_web_search` returns results.
