### PR TITLE
fix: Claude Desktop example was forcing HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Options:
 
 ### Usage with Claude Desktop
 
+Claude Desktop talks over stdio. The npx example below used to pass `--transport http`, which starts a web server the Desktop client never connects to (usually lands as connection closed / -32000).
+
 Add this to your `claude_desktop_config.json`:
 
 #### Docker
@@ -229,7 +231,7 @@ Add this to your `claude_desktop_config.json`:
   "mcpServers": {
     "brave-search": {
       "command": "npx",
-      "args": ["-y", "@brave/brave-search-mcp-server", "--transport", "http"],
+      "args": ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
       "env": {
         "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
       }

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import express, { type Request, type Response } from 'express';
 import config from '../config.js';
 import createMcpServer from '../server.js';
+import { isLoopbackHostname } from '../utils.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ListToolsRequest, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { createDnsRebindingGuard } from './rebinding.js';
@@ -102,6 +103,13 @@ const start = () => {
 
   app.listen(config.port, config.host, () => {
     console.log(`Server is running on http://${config.host}:${config.port}/mcp`);
+
+    // /mcp has no auth today. Binding past loopback is an easy way to leak quota.
+    if (!isLoopbackHostname(config.host)) {
+      console.error(
+        `Warning: HTTP transport is bound to ${config.host} and /mcp is unauthenticated. Prefer 127.0.0.1 for local use, or put a reverse proxy with auth in front of this process.`
+      );
+    }
   });
 };
 


### PR DESCRIPTION
hey @jonathansampson

two related footguns:

1. the Claude Desktop npx snippet in the README was passing `--transport http`. Desktop only talks stdio, so that config just spins up a local web server the client never hits — usually shows up as connection closed / -32000. lined it up with the VS Code example (`--transport stdio`). related to the install pain in #80.

2. when HTTP is bound past loopback (`0.0.0.0`, LAN IP, etc.) we now print a stderr warning. `/mcp` still has no auth on main (see #338), and `docker-compose.yml` defaults to `BRAVE_MCP_HOST=0.0.0.0`, so this is easy to miss. related to #327 — not a substitute for the bearer token, just a heads-up until that lands.

`npm test` / `npm run build` green locally.