### PR TITLE
fix: fetch /local/pois when enriching brave_local_search

### DIFF
--- a/src/tools/local/index.test.ts
+++ b/src/tools/local/index.test.ts
@@ -4,13 +4,40 @@ import { useTestClient } from '../../testUtils/mcpTestHarness.js';
 import { name } from './index.js';
 
 describe(name, () => {
+  const seenPaths: string[] = [];
+
   const getClient = useTestClient((url) => {
+    seenPaths.push(url.pathname);
+
     if (url.pathname === '/res/v1/web/search') {
       return {
         type: 'search',
         locations: {
           results: [{ id: 'poi-1', title: 'Brave Coffee Shop' }],
         },
+      };
+    }
+
+    if (url.pathname === '/res/v1/local/pois') {
+      return {
+        type: 'local_pois',
+        results: [
+          {
+            type: 'location_result',
+            id: 'poi-1',
+            title: 'Brave Coffee Shop',
+            url: 'https://example.com/brave-coffee',
+            is_source_local: true,
+            is_source_both: false,
+            family_friendly: true,
+            provider_url: 'https://example.com/provider',
+            zoom_level: 14,
+            contact: { telephone: '+1-415-555-0100' },
+            rating: { ratingValue: 4.6, reviewCount: 128 },
+            postal_address: { displayAddress: '1 Market St, San Francisco, CA' },
+            price_range: '$$',
+          },
+        ],
       };
     }
 
@@ -23,6 +50,8 @@ describe(name, () => {
   });
 
   it('returns enriched location results for a simple query', async () => {
+    seenPaths.length = 0;
+
     const result = await getClient().callTool({
       name,
       arguments: { query: 'coffee shops in san francisco' },
@@ -30,6 +59,13 @@ describe(name, () => {
 
     assert.equal(result.isError ?? false, false, JSON.stringify(result.content));
     assert.ok(Array.isArray(result.content) && result.content.length > 0);
+    assert.ok(seenPaths.includes('/res/v1/local/pois'), 'should hit /local/pois');
+    assert.ok(seenPaths.includes('/res/v1/local/descriptions'), 'should hit /local/descriptions');
+
+    const text = (result.content as { text: string }[])[0].text;
+    assert.match(text, /\+1-415-555-0100/);
+    assert.match(text, /1 Market St/);
+    assert.match(text, /A cozy coffee shop/);
   });
 });
 

--- a/src/tools/local/index.ts
+++ b/src/tools/local/index.ts
@@ -60,13 +60,18 @@ export const execute = async (params: WebQueryParams) => {
     };
   }
 
-  // Fetch AI-generated descriptions
-  const descriptions = await API.issueRequest<'localDescriptions'>('localDescriptions', {
-    ids: locationIDs,
-  });
+  // Web only gives thin location stubs (mostly id + title). The Local POIs
+  // endpoint is what fills in phone / hours / rating / address; descriptions
+  // are a separate AI-generated blurb keyed by the same ids.
+  const [pois, descriptions] = await Promise.all([
+    API.issueRequest<'localPois'>('localPois', { ids: locationIDs }),
+    API.issueRequest<'localDescriptions'>('localDescriptions', { ids: locationIDs }),
+  ]);
+
+  const poiResults = pois.results?.length ? pois.results : locations.results;
 
   return {
-    content: formatLocalResults(locations.results, descriptions.results).map((formattedPOI) => ({
+    content: formatLocalResults(poiResults, descriptions.results ?? []).map((formattedPOI) => ({
       type: 'text' as const,
       text: formattedPOI,
     })),


### PR DESCRIPTION
hey @jonathansampson

the local search tool was only returning thin web stubs (id + title) plus
AI-generated descriptions. it was never calling the `/local/pois` endpoint
that actually fills in phone, hours, rating, address, etc.

this change:
- after collecting location IDs from the web step, calls both
  `/local/pois` and `/local/descriptions` in parallel
- formats the POI results (phone, hours, rating, address, …) and merges
  the description by id
- falls back to the web stubs if pois comes back empty (keeps existing
  behavior when the user lacks a Pro plan or the query yields no locations)
- updates the test to assert a `/local/pois` hit and check for phone/hours

related to the local search docs (no open issue, just a docs/code mismatch).

`npm test` and `npm run build` are green locally.