### PR TITLE
fix: drop closed http sessions and shut down cleanly

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,7 +4,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 export function registerSigIntHandler(
   transports: Map<string, StdioServerTransport | StreamableHTTPServerTransport>
 ) {
-  process.on('SIGINT', async () => {
+  const shutdown = async () => {
     for (const sessionID of transports.keys()) {
       await transports.get(sessionID)?.close();
       transports.delete(sessionID);
@@ -12,5 +12,8 @@ export function registerSigIntHandler(
 
     console.error('Server shut down.');
     process.exit(0);
-  });
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 }

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import express, { type Request, type Response } from 'express';
 import config from '../config.js';
+import { registerSigIntHandler } from '../helpers.js';
 import createMcpServer from '../server.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ListToolsRequest, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -19,12 +20,18 @@ const transports = new Map<string, StreamableHTTPServerTransport>();
 const isListToolsRequest = (value: unknown): value is ListToolsRequest =>
   ListToolsRequestSchema.safeParse(value).success;
 
-const getTransport = async (request: Request): Promise<StreamableHTTPServerTransport> => {
+type ResolvedTransport = {
+  transport: StreamableHTTPServerTransport;
+  // One-shot transports (stateless / bare tools/list) are not kept in `transports`.
+  ephemeral: boolean;
+};
+
+const getTransport = async (request: Request): Promise<ResolvedTransport> => {
   // Check for an existing session
   const sessionId = request.headers['mcp-session-id'] as string;
 
   if (sessionId && transports.has(sessionId)) {
-    return transports.get(sessionId)!;
+    return { transport: transports.get(sessionId)!, ephemeral: false };
   }
 
   // We have a special case where we'll permit ListToolsRequest w/o a session ID
@@ -35,29 +42,34 @@ const getTransport = async (request: Request): Promise<StreamableHTTPServerTrans
 
     const mcpServer = createMcpServer();
     await mcpServer.connect(transport);
-    return transport;
+    return { transport, ephemeral: true };
   }
 
   let transport: StreamableHTTPServerTransport;
+  let ephemeral = false;
 
   if (config.stateless) {
     // Some contexts (e.g. AgentCore) may prefer or require a stateless transport
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     });
+    ephemeral = true;
   } else {
     // Otherwise, start a new transport/session
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
-      onsessioninitialized: (sessionId) => {
-        transports.set(sessionId, transport);
+      onsessioninitialized: (id) => {
+        transports.set(id, transport);
+      },
+      onsessionclosed: (id) => {
+        transports.delete(id);
       },
     });
   }
 
   const mcpServer = createMcpServer();
   await mcpServer.connect(transport);
-  return transport;
+  return { transport, ephemeral };
 };
 
 const createApp = () => {
@@ -74,13 +86,20 @@ const createApp = () => {
   app.use('/mcp', express.json());
 
   app.all('/mcp', async (req: Request, res: Response) => {
+    let ephemeral = false;
+    let transport: StreamableHTTPServerTransport | undefined;
+
     try {
-      const transport = await getTransport(req);
+      ({ transport, ephemeral } = await getTransport(req));
       await transport.handleRequest(req, res, req.body);
     } catch (error) {
       console.error(error);
       if (!res.headersSent) {
         yieldGenericServerError(res);
+      }
+    } finally {
+      if (ephemeral && transport) {
+        await transport.close().catch(() => undefined);
       }
     }
   });
@@ -97,6 +116,8 @@ const start = () => {
     console.error('Invalid configuration');
     process.exit(1);
   }
+
+  registerSigIntHandler(transports);
 
   const app = createApp();
 


### PR DESCRIPTION
hey @jonathansampson

stateful HTTP transports were only ever added to the global `transports`
map, never removed on DELETE / session close. one-shot transports (used
for bare `tools/list` without a session) also piled up. this change:

- adds an `onsessionclosed` callback to delete the session from the map
- makes the existing `registerSigIntHandler` also run on SIGTERM so a
  long-lived HTTP process can exit cleanly
- ensures one-shot transports are closed after handling the request

this prevents session leaks in long-running HTTP deployments (e.g. when
using docker-compose with `BRAVE_MCP_HOST=0.0.0.0`).

related to #327 (optional HTTP bearer token) and the observability in
#80-style connection failures.

`npm test` and `npm run build` are green locally.