### PR TITLE
fix: default news freshness to pd and harden empty results

### DIFF
--- a/src/tools/news/index.test.ts
+++ b/src/tools/news/index.test.ts
@@ -31,3 +31,20 @@ describe(name, () => {
     assert.ok(Array.isArray(result.content) && result.content.length > 0);
   });
 });
+
+describe(`${name} (empty upstream payload)`, () => {
+  const getClient = useTestClient((url) => {
+    if (url.pathname === '/res/v1/news/search') {
+      return {};
+    }
+  });
+
+  it('returns a clear empty-result message instead of throwing', async () => {
+    const result = await getClient().callTool({ name, arguments: { query: 'brave browser' } });
+
+    assert.equal(result.isError ?? false, false, JSON.stringify(result.content));
+    assert.deepEqual(result.content, [
+      { type: 'text', text: 'No news results found for this query.' },
+    ]);
+  });
+});

--- a/src/tools/news/index.ts
+++ b/src/tools/news/index.ts
@@ -32,9 +32,16 @@ export const description = `
 
 export const execute = async (params: QueryParams) => {
   const response = await API.issueRequest<'news'>('news', params);
+  const results = response.results ?? [];
+
+  if (results.length === 0) {
+    return {
+      content: [{ type: 'text' as const, text: 'No news results found for this query.' }],
+    };
+  }
 
   return {
-    content: response.results.map((newsResult) => {
+    content: results.map((newsResult) => {
       return {
         type: 'text' as const,
         text: stringify({

--- a/src/tools/news/params.test.ts
+++ b/src/tools/news/params.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import params from './params.js';
+
+describe('news freshness', () => {
+  it('defaults to pd (last 24 hours), matching the README', () => {
+    const parsed = params.parse({ query: 'brave browser' });
+    assert.equal(parsed.freshness, 'pd');
+  });
+});

--- a/src/tools/news/params.ts
+++ b/src/tools/news/params.ts
@@ -63,8 +63,9 @@ export const params = z.object({
           "Use 'pd', 'pw', 'pm', or 'py' for a relative discovery window, or a custom range as YYYY-MM-DDtoYYYY-MM-DD (e.g. 2022-04-01to2022-07-30)."
         ),
     ])
+    .default('pd')
     .describe(
-      "Filters search results by when they were discovered. The following values are supported: 'pd' - Discovered within the last 24 hours. 'pw' - Discovered within the last 7 Days. 'pm' - Discovered within the last 31 Days. 'py' - Discovered within the last 365 Days. 'YYYY-MM-DDtoYYYY-MM-DD' - Timeframe is also supported by specifying the date range e.g. 2022-04-01to2022-07-30."
+      "Filters search results by when they were discovered. The following values are supported: 'pd' - Discovered within the last 24 hours. 'pw' - Discovered within the last 7 Days. 'pm' - Discovered within the last 31 Days. 'py' - Discovered within the last 365 Days. 'YYYY-MM-DDtoYYYY-MM-DD' - Timeframe is also supported by specifying the date range e.g. 2022-04-01to2022-07-30. Defaults to 'pd'."
     )
     .optional(),
   extra_snippets: z

--- a/src/tools/videos/index.test.ts
+++ b/src/tools/videos/index.test.ts
@@ -34,3 +34,20 @@ describe(name, () => {
     assert.ok(Array.isArray(result.content) && result.content.length > 0);
   });
 });
+
+describe(`${name} (empty upstream payload)`, () => {
+  const getClient = useTestClient((url) => {
+    if (url.pathname === '/res/v1/videos/search') {
+      return {};
+    }
+  });
+
+  it('returns a clear empty-result message instead of throwing', async () => {
+    const result = await getClient().callTool({ name, arguments: { query: 'brave browser' } });
+
+    assert.equal(result.isError ?? false, false, JSON.stringify(result.content));
+    assert.deepEqual(result.content, [
+      { type: 'text', text: 'No video results found for this query.' },
+    ]);
+  });
+});

--- a/src/tools/videos/index.ts
+++ b/src/tools/videos/index.ts
@@ -23,9 +23,16 @@ export const description = `
 
 export const execute = async (params: QueryParams) => {
   const response = await API.issueRequest<'videos'>('videos', params);
+  const results = response.results ?? [];
+
+  if (results.length === 0) {
+    return {
+      content: [{ type: 'text' as const, text: 'No video results found for this query.' }],
+    };
+  }
 
   return {
-    content: response.results.map(({ url, title, description, video, thumbnail }) => {
+    content: results.map(({ url, title, description, video, thumbnail }) => {
       const duration = video?.duration;
       const thumbnail_url = thumbnail?.src;
 


### PR DESCRIPTION
hey @jonathansampson

two small news/videos fixes:

1. the README says news `freshness` defaults to "pd" (last 24 hours),
   but the schema left it unset — so the API got no freshness at all and
   returned stale results. now the schema defaults to `pd` to match the
   docs. callers who explicitly pass a value are unaffected.

2. news and videos did `response.results.map(...)` with no guard, so an
   upstream response without `results` (rate-limit edge cases, odd
   payloads) blew up the tool with an opaque error instead of a clean
   empty message. both now return "No news results found for this query."
   / "No video results found for this query." instead of throwing.

tests: freshness default + empty-payload paths for both tools.

`npm test` and `npm run build` are green locally.