### PR TITLE
docs: stop telling agents image search has an offset

### DIFF
--- a/src/tools/images/schemas/input.ts
+++ b/src/tools/images/schemas/input.ts
@@ -29,7 +29,7 @@ export const params = z.object({
     .max(200)
     .default(50)
     .describe(
-      'Number of results (1-200, default 50). Combine this parameter with `offset` to paginate search results.'
+      'Number of results (1-200, default 50). Image Search is not paginated — raise `count` if you need more results. There is no `offset` parameter.'
     )
     .optional(),
   safesearch: z


### PR DESCRIPTION
hey @jonathansampson

small one. the image search `count` description said to "combine this
parameter with `offset` to paginate search results" — but the Image
Search API has no `offset` parameter at all. it's not paginated; you just
raise `count` (max 200).

agents reading the schema kept inventing an `offset` that doesn't exist
and wasting calls. the README already omits offset for images, so this
aligns the schema text with reality.

`npm test` and `npm run build` are green locally.